### PR TITLE
feat: add page shortcut key for datasets

### DIFF
--- a/app/projects/[projectId]/datasets/[datasetId]/page.js
+++ b/app/projects/[projectId]/datasets/[datasetId]/page.js
@@ -161,6 +161,10 @@ export default function DatasetDetailsPage({ params }) {
   // 获取数据集列表（用于导航）
   const [datasets, setDatasets] = useState([]);
   const { t } = useTranslation();
+  const [shortcutsEnabled, setShortcutsEnabled] = useState(() => {
+    const storedValue = localStorage.getItem('shortcutsEnabled');
+    return storedValue !== null ? storedValue === 'true' : false;
+  });
 
   // 从本地存储获取模型参数
   const getModelFromLocalStorage = () => {
@@ -456,6 +460,42 @@ export default function DatasetDetailsPage({ params }) {
     }
   };
 
+  // 快捷键状态变化
+  useEffect(() => {
+    localStorage.setItem('shortcutsEnabled', shortcutsEnabled);
+  }, [shortcutsEnabled]);
+
+  // 监听键盘事件
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (!shortcutsEnabled) return;
+      switch (event.key) {
+        case 'ArrowLeft': // 上一个
+          handleNavigate('prev');
+          break;
+        case 'ArrowRight': // 下一个
+          handleNavigate('next');
+          break;
+        case 'y': // 确认
+        case 'Y':
+          if (!confirming && !dataset?.confirmed) {
+            handleConfirm();
+          }
+          break;
+        case 'd': // 删除
+        case 'D':
+          handleDelete();
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [shortcutsEnabled, confirming, dataset]);
+
   if (loading) {
     return (
       <Container maxWidth="lg" sx={{ mt: 4 }}>
@@ -492,6 +532,21 @@ export default function DatasetDetailsPage({ params }) {
                 percentage: Math.round((datasets.filter(d => d.confirmed).length / datasets.length) * 100)
               })}
             </Typography>
+          </Box>
+          {/* 快捷键启用选项 */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Typography variant="body1">{t('datasets.enableShortcuts')}</Typography>
+            <Tooltip title={t('datasets.shortcutsHelp')}>
+              <IconButton size="small" color="info">
+                <Typography variant="body1" sx={{ fontWeight: 'bold' }}>?</Typography>
+              </IconButton>
+            </Tooltip>
+            <Button
+              variant={shortcutsEnabled ? 'contained' : 'outlined'}
+              onClick={() => setShortcutsEnabled((prev) => !prev)}
+            >
+              {shortcutsEnabled ? t('common.enabled') : t('common.disabled')}
+            </Button>
           </Box>
           <Box sx={{ display: 'flex', gap: 1 }}>
             <IconButton onClick={() => handleNavigate('prev')}>

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -370,7 +370,9 @@
     "generateSuccess": "Successfully generated dataset for: {{question}}",
     "generateFailed": "Failed to generate dataset: {{error}}",
     "noTagsAndQuestions": "No tags and questions available",
-    "answerCount": "{{count}} Answers"
+    "answerCount": "{{count}} Answers",
+    "enableShortcuts": "Page shortcut key",
+    "shortcutsHelp": "Press ← forward, press → backward, press y to confirm, press d to delete"
   },
   "update": {
     "newVersion": "New Version",

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -128,7 +128,9 @@
     "deleteSuccess": "删除成功",
     "visitGitHub": "访问GitHub仓库",
     "copy": "复制",
-    "copied": "已复制"
+    "copied": "已复制",
+    "enabled": "已启用",
+    "disabled": "已禁用"
   },
   "home": {
     "title": "Easy Dataset",
@@ -370,7 +372,9 @@
     "generateSuccess": "成功生成数据集：{{question}}",
     "generateFailed": "生成数据集失败：{{error}}",
     "noTagsAndQuestions": "暂无标签和问题",
-    "answerCount": "{{count}} 个答案"
+    "answerCount": "{{count}} 个答案",
+    "enableShortcuts": "翻页快捷键",
+    "shortcutsHelp": "按 ← 向前，按 → 向后，按 y 确认，按 d 删除"
   },
   "update": {
     "newVersion": "新版本",


### PR DESCRIPTION
## 变更类型
- [x] 新功能（feat）
- [ ] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）

## 变更描述
- 数据集详情页面增加快捷键，支持←向前一道题，→向后一道题，y确认保留，d删除。

## 文档更新
- [ ] README.md
- [ ] 贡献指南
- [ ] 接口文档（如有）