### PR TITLE
fix: Prevent error when processing removed PDF files

### DIFF
--- a/app/projects/[projectId]/text-split/page.js
+++ b/app/projects/[projectId]/text-split/page.js
@@ -109,34 +109,38 @@ export default function TextSplitPage({ params }) {
   const handleUploadSuccess = async (fileNames, model,pdfFiles) => {
     console.log(t('textSplit.fileUploadSuccess'), fileNames);
     //上传完处理PDF文件
-    try{
-      setPdfProcessing(true);
-      setError(null);
-      // 重置进度状态
-      setProgress({
-        total: pdfFiles.length,
-        completed: 0,
-        percentage: 0,
-        questionCount: 0
-      });
-      const currentLanguage = i18n.language === 'zh-CN' ? '中文' : 'en';
-      for(const file of pdfFiles){
-        const response = await fetch(`/api/projects/${projectId}/pdf?fileName=`+file.name+`&strategy=`+pdfStrategy+`&currentLanguage=`+currentLanguage+`&modelId=`+selectedViosnModel);
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(t('textSplit.pdfProcessingFailed') + errorData.error);
-        }
-        const data = await response.json();
-        // 更新进度状态
-        setProgress(prev => {
-          const completed = prev.completed + 1;
-          const percentage = Math.round((completed / prev.total) * 100);
-          return {
-            ...prev,
-            completed,
-            percentage
-          };
+    try {
+      // 过滤 pdfFiles 列表，只保留那些在当前成功上传的文件列表 (fileNames) 中存在的 PDF 文件
+      const successfullyUploadedPdfs = pdfFiles.filter(pdfFile => fileNames.includes(pdfFile.name));
+      if (successfullyUploadedPdfs.length > 0) {
+        setPdfProcessing(true);
+        setError(null);
+        // 重置进度状态
+        setProgress({
+          total: pdfFiles.length,
+          completed: 0,
+          percentage: 0,
+          questionCount: 0
         });
+        const currentLanguage = i18n.language === 'zh-CN' ? '中文' : 'en';
+        for(const file of pdfFiles){
+          const response = await fetch(`/api/projects/${projectId}/pdf?fileName=`+file.name+`&strategy=`+pdfStrategy+`&currentLanguage=`+currentLanguage+`&modelId=`+selectedViosnModel);
+          if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(t('textSplit.pdfProcessingFailed') + errorData.error);
+          }
+          const data = await response.json();
+          // 更新进度状态
+          setProgress(prev => {
+            const completed = prev.completed + 1;
+            const percentage = Math.round((completed / prev.total) * 100);
+            return {
+              ...prev,
+              completed,
+              percentage
+            };
+          });
+        }
       }
     }catch(error){
       console.error(t('textSplit.pdfProcessingFailed'), error);


### PR DESCRIPTION
### 变更类型
- [x] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）

### 变更描述
- 问题：在文本处理页面 (text-split)，如果用户执行以下操作：
  - 选择一个或多个 PDF 文件进行上传。
  - 在点击“上传文件并处理”按钮之前，从待上传列表中移除了某个 PDF 文件。
  - 点击“上传文件并处理”按钮，上传了剩余的文件（可能是其他 PDF 或 Word 文件）。
  - 此时，[handleUploadSuccess]函数仍然会尝试处理那个已经被移除（并未实际上传）的 PDF 文件，导致在调用 PDF 处理 API (/api/projects/[projectId]/pdf) 时，由于找不到文件而抛出 ENOENT: no such file or directory 错误
- 在进入 PDF 处理循环之前，使用 .filter() 方法对 [pdfFiles] 数组（包含用户界面中选择的所有 PDF 文件信息）进行过滤。
- 过滤条件是检查 [pdfFiles]中的每个文件名是否存在于 [fileNames]数组（包含当前批次实际成功上传的文件名列表）中。
- 只有那些确实在当前批次成功上传的 PDF 文件（存储在新的 [successfullyUploadedPdfs]数组中）才会被用于后续的 PDF 处理循环和 API 调用。

### 文档更新- [ ] README.md
- [ ] 贡献指南
- [ ] 接口文档（如有）