### PR TITLE
fix: Ensure pdfFiles list stays in sync when a PDF is deleted before upload.

### DIFF
--- a/app/projects/[projectId]/text-split/page.js
+++ b/app/projects/[projectId]/text-split/page.js
@@ -95,37 +95,33 @@ export default function TextSplitPage({ params }) {
     console.log(t('textSplit.fileUploadSuccess'), fileNames);
     //上传完处理PDF文件
     try {
-      // 过滤 pdfFiles 列表，只保留那些在当前成功上传的文件列表 (fileNames) 中存在的 PDF 文件
-      const successfullyUploadedPdfs = pdfFiles.filter(pdfFile => fileNames.includes(pdfFile.name));
-      if (successfullyUploadedPdfs.length > 0) {
-        setPdfProcessing(true);
-        setError(null);
-        // 重置进度状态
-        setProgress({
-          total: pdfFiles.length,
-          completed: 0,
-          percentage: 0,
-          questionCount: 0
-        });
-        const currentLanguage = i18n.language === 'zh-CN' ? '中文' : 'en';
-        for(const file of pdfFiles){
-          const response = await fetch(`/api/projects/${projectId}/pdf?fileName=`+file.name+`&strategy=`+pdfStrategy+`&currentLanguage=`+currentLanguage+`&modelId=`+selectedViosnModel);
-          if (!response.ok) {
-            const errorData = await response.json();
-            throw new Error(t('textSplit.pdfProcessingFailed') + errorData.error);
-          }
-          const data = await response.json();
-          // 更新进度状态
-          setProgress(prev => {
-            const completed = prev.completed + 1;
-            const percentage = Math.round((completed / prev.total) * 100);
-            return {
-              ...prev,
-              completed,
-              percentage
-            };
-          });
+      setPdfProcessing(true);
+      setError(null);
+      // 重置进度状态
+      setProgress({
+        total: pdfFiles.length,
+        completed: 0,
+        percentage: 0,
+        questionCount: 0
+      });
+      const currentLanguage = i18n.language === 'zh-CN' ? '中文' : 'en';
+      for (const file of pdfFiles) {
+        const response = await fetch(`/api/projects/${projectId}/pdf?fileName=` + file.name + `&strategy=` + pdfStrategy + `&currentLanguage=` + currentLanguage + `&modelId=` + selectedViosnModel);
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(t('textSplit.pdfProcessingFailed') + errorData.error);
         }
+        const data = await response.json();
+        // 更新进度状态
+        setProgress(prev => {
+          const completed = prev.completed + 1;
+          const percentage = Math.round((completed / prev.total) * 100);
+          return {
+            ...prev,
+            completed,
+            percentage
+          };
+        });
       }
     } catch (error) {
       console.error(t('textSplit.pdfProcessingFailed'), error);

--- a/components/text-split/FileUploader.js
+++ b/components/text-split/FileUploader.js
@@ -163,7 +163,14 @@ export default function FileUploader({
 
   // 移除文件
   const removeFile = index => {
+    // 获取将要被移除的文件信息
+    const fileToRemove = files[index];
+    // 更新 files 状态，移除该文件
     setFiles(prev => prev.filter((_, i) => i !== index));
+    // 如果被移除的文件是 PDF，则同时更新 pdfFiles 状态
+    if (fileToRemove && fileToRemove.name.toLowerCase().endsWith('.pdf')) {
+      setPdfFiles(prevPdfFiles => prevPdfFiles.filter(pdfFile => pdfFile.name !== fileToRemove.name));
+    }
   };
 
   // 上传文件


### PR DESCRIPTION
### 变更类型
- [x] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）

### 变更描述
- 问题：在文本处理页面 (text-split)，如果用户执行以下操作：
  - 选择一个或多个 PDF 文件进行上传。
  - 在点击“上传文件并处理”按钮之前，从待上传列表中移除了某个 PDF 文件。
  - 点击“上传文件并处理”按钮，上传了剩余的文件（可能是其他 PDF 或 Word 文件）。
  - 此时，[handleUploadSuccess]函数仍然会尝试处理那个已经被移除（并未实际上传）的 PDF 文件，导致在调用 PDF 处理 API (/api/projects/[projectId]/pdf) 时，由于找不到文件而抛出 ENOENT: no such file or directory 错误


- 解决
之前的修复措施是基于mian分支进行修复，但发现在dev分支上会直接产生无法上传处理pdf的新bug，所以重新进行了问题排查，发现是在未上传文件之前如果对pdf进行删除操作，只对file列表进行了更新而没有对pdfFile列表进行更新操作，导致状态不同步，所以产生了无法找到相应pdf的报错

- 检查
经过检查发现此次修正在main分支和dev分支上均可解决问题而不产生新的问题

### 文档更新- [ ] README.md
- [ ] 贡献指南
- [ ] 接口文档