### PR TITLE
fix: CoT from deepseek-r1 deployed by sglang 0.4.6 cannot be recognized

### DIFF
--- a/lib/llm/core/index.js
+++ b/lib/llm/core/index.js
@@ -120,6 +120,9 @@ class LLMClient {
     if (answer.startsWith('<think>') || answer.startsWith('<thinking>')) {
       cot = extractThinkChain(answer);
       answer = extractAnswer(answer);
+    } else if (llmRes?.response?.body?.choices !== undefined) {
+      cot = llmRes.response.body.choices[0].message.reasoning_content || '';
+      answer = llmRes.response.body.choices[0].message.content || '';
     }
     if (answer.startsWith('\n\n')) {
       answer = answer.slice(2);


### PR DESCRIPTION
Fix #308 : CoT from deepseek-r1 deployed by sglang 0.4.6 cannot be successfully recognized since the reasoning content is seperated as ".reasoning_content" from ".content"