### PR TITLE
fix docker environment for linux/arm64

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["darwin-arm64", "darwin", "windows", "debian-openssl-3.0.x"]
+  binaryTargets = ["darwin-arm64", "darwin", "windows", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
### 变更类型- [ ] 新功能（feat）

- [X] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）

### 变更描述- 简要说明修改内容（关联Issue：#123）
解决在linux/arm64环境下构造docker镜像后，启动服务时不能创建项目的问题。
docker logs具体报错信息如下：
```bash
prisma:error
Invalid `prisma.projects.findMany()` invocation:


Prisma Client could not locate the Query Engine for runtime "linux-arm64-openssl-3.0.x".

This happened because `binaryTargets` have been pinned, but the actual deployment also required "linux-arm64-openssl-3.0.x".
Add "linux-arm64-openssl-3.0.x" to `binaryTargets` in the "schema.prisma" file and run `prisma generate` after saving it:

generator client {
  provider      = "prisma-client-js"
  binaryTargets = ["darwin-arm64", "darwin", "windows", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
}

The following locations have been searched:
  /app/node_modules/.pnpm/@prisma+client@6.7.0_prisma@6.7.0_typescript@5.8.3__typescript@5.8.3/node_modules/.prisma/client
  /app/node_modules/.pnpm/@prisma+client@6.7.0_prisma@6.7.0_typescript@5.8.3__typescript@5.8.3/node_modules/@prisma/client
  /tmp/prisma-engines
  /app/prisma
Failed to get projects in database
获取项目列表出错: PrismaClientInitializationError:

```
### 文档更新- [ ] README.md

- [ ] 贡献指南
- [ ] 接口文档（如有）
