### PR TITLE
Add Docker build workflow and multi-platform support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,48 @@
+name: Build and Push Docker image on Tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  docker-image-release:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/easy-dataset
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["darwin-arm64", "darwin", "windows", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x", "linux-musl-openssl-3.0.x"]
+  binaryTargets = ["darwin-arm64", "darwin", "windows", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
### 变更类型
- [x] 新功能（feat）

### 变更描述- 简要说明修改内容（关联Issue：#123）

添加自动化Docker镜像构建和发布功能，并优化了对多平台（AMD64/ARM64）的支持。
通过GitHub Actions工作流，在推送标签时自动构建并发布Docker镜像到GitHub Container Registry。

#### 使用方式

1. 推送标签触发工作流：

  ```bash
  git tag 1.x.x
  git push origin 1.x.x
  ```

2. 在GitHub Actions中验证工作流执行情况，[示例](https://github.com/DDDDD12138/easy-dataset/actions)

3. 拉取并测试构建的镜像：

  ```bash
  docker pull ghcr.io/[用户名]/easy-dataset
  docker run -p 1717:1717 ghcr.io/[用户名]/easy-dataset
  ```


### 文档更新- [ ] README.md

- [ ] 贡献指南
- [ ] 接口文档（如有）
