### PR TITLE
fix the error when cleaning up domain information during file deletion

### DIFF
--- a/app/api/projects/[projectId]/files/route.js
+++ b/app/api/projects/[projectId]/files/route.js
@@ -122,7 +122,7 @@ export async function DELETE(request, { params }) {
         project
       });
 
-      const tocPath = path.join(fileInfo.path, '../toc', fileInfo.fileName.replace('.md', '') + '-toc.json');
+      const tocPath = path.join(fileInfo.path, '../toc', fileInfo.fileName.replace(/\.[^/.]+$/, '') + '-toc.json');
       await fs.rm(tocPath, { recursive: true });
     } catch (error) {
       console.error('Error updating domain tree after file deletion:', error);


### PR DESCRIPTION
### 变更类型
- [ ] 新功能（feat）
- [x] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）

### 变更描述- 简要说明修改内容
- 修复删除文件时，清理.toc文件出错的bug
![image](https://github.com/user-attachments/assets/8aa78b7e-a8e2-411e-95c0-f2bff8ef614c)

### 文档更新
- [ ] README.md
- [ ] 贡献指南
- [ ] 接口文档（如有）