### PR TITLE
Add Docker Compose support for easier deployment

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,5 @@
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
 DATABASE_URL="file:./db.sqlite"
+
+LOCAL_DB_PATH=./local-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   easy-dataset:
-    image: ghcr.io/ddddd12138/easy-dataset
+    image: ghcr.io/conardli/easy-dataset
     container_name: easy-dataset
     ports:
       - '1717:1717'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  easy-dataset:
+    image: ghcr.io/ddddd12138/easy-dataset
+    container_name: easy-dataset
+    ports:
+      - '1717:1717'
+    volumes:
+      - ${LOCAL_DB_PATH}:/app/local-db
+    restart: unless-stopped


### PR DESCRIPTION
### 变更类型
- [x] 新功能（feat）

### 变更描述- 简要说明修改内容

添加了 Docker Compose 支持，大大简化了部署流程，用户现在只需要 `docker-compose up -d` 即可完成部署，无需本地构建

#### 希望对文档进行以下更新：

````md
## Docker 启动（适合私有部署）

如果你想在云服务或者内网环境私有部署，可以使用 Docker Compose：

1. 克隆仓库：
   ``bash
   git clone https://github.com/ConardLi/easy-dataset.git
   cd easy-dataset
   ```
2. 启动服务：

   ```bash
   docker-compose up -d
   ```

3. 访问应用： 打开浏览器访问 `http://localhost:1717`

注意：数据将默认存储在项目根目录的 `./local-db` 文件夹中。如需修改数据存储路径，请编辑 `.env` 文件中的 `LOCAL_DB_PATH` 变量。

````

- [ ] 贡献指南
- [x] 接口文档（如有）
