### PR TITLE
Fixed a bug when parsing LLM responses as JSON.

### DIFF
--- a/lib/llm/common/util.js
+++ b/lib/llm/common/util.js
@@ -11,7 +11,10 @@ function extractJsonFromLLMOutput(output) {
   const jsonStart = output.indexOf('```json');
   const jsonEnd = output.lastIndexOf('```');
   if (jsonStart !== -1 && jsonEnd !== -1) {
-    const jsonString = output.substring(jsonStart + 7, jsonEnd);
+    const regex = /```json\s*([\s\S]*?)```/
+    const match = regex.exec(output);
+
+    const jsonString = match[1].trim();
     try {
       const json = JSON.parse(jsonString);
       return json;


### PR DESCRIPTION
The existing LLM parsing logic cuts and retrieves the string inside ```json ``` through jsonStart and jsonEnd.
There is no problem when there is only one character in the ```json ``` format, but under certain conditions,
I confirmed that there were two pieces of ```json ``` data containing the same value in the LLM response, and proper parsing did not occur.
To handle the exception, I changed it to store the data in an array using a regular expression and proceed with subsequent processing with the first value.

### 变更类型- [ ] 新功能（feat）

- [x] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）

### 变更描述- 简要说明修改内容（关联Issue：#123）

### 文档更新- [ ] README.md

- [ ] 贡献指南
- [ ] 接口文档（如有）
