### PR TITLE
* HuggingFaceH4/Multilingual-Thinking use for gpt-oss LLM fine-tuning…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With Easy Dataset, you can transform domain knowledge into structured datasets, 
 - **Domain Labels**: Intelligently builds global domain labels for datasets, with global understanding capabilities
 - **Answer Generation**: Uses LLM API to generate comprehensive answers and Chain of Thought (COT)
 - **Flexible Editing**: Edit questions, answers, and datasets at any stage of the process
-- **Multiple Export Formats**: Export datasets in various formats (Alpaca, ShareGPT) and file types (JSON, JSONL)
+- **Multiple Export Formats**: Export datasets in various formats (Alpaca, ShareGPT, multilingual-thinking) and file types (JSON, JSONL)
 - **Wide Model Support**: Compatible with all LLM APIs that follow the OpenAI format
 - **User-Friendly Interface**: Intuitive UI designed for both technical and non-technical users
 - **Custom System Prompts**: Add custom system prompts to guide model responses
@@ -254,7 +254,7 @@ docker run -d \
 </table>
 
 1. Click the "Export" button in the Datasets section;
-2. Choose your preferred format (Alpaca or ShareGPT);
+2. Choose your preferred format (Alpaca or ShareGPT or multilingual-thinking);
 3. Select the file format (JSON or JSONL);
 4. Add custom system prompts as needed;
 5. Export your dataset

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -256,7 +256,7 @@ docker run -d \
 </table>
 
 1. 在数据集部分点击"导出"按钮；
-2. 选择您喜欢的格式（Alpaca 或 ShareGPT）；
+2. 选择您喜欢的格式（Alpaca 或 ShareGPT 或 multilingual-thinking）；
 3. 选择文件格式（JSON 或 JSONL）；
 4. 根据需要添加自定义系统提示；
 5. 导出您的数据集

--- a/app/api/projects/[projectId]/huggingface/upload/route.js
+++ b/app/api/projects/[projectId]/huggingface/upload/route.js
@@ -19,7 +19,8 @@ export async function POST(request, { params }) {
       confirmedOnly,
       includeCOT,
       fileFormat,
-      customFields
+      customFields,
+      reasoningLanguage
     } = await request.json();
 
     // 获取项目信息
@@ -162,7 +163,48 @@ function formatDataset(questions, formatType, systemPrompt, includeCOT, customFi
 
       return { messages };
     });
-  } else if (formatType === 'custom' && customFields) {
+  } else if (formatType === 'multilingualthinking') {
+  return questions.map(q => {
+    const messages = [];
+
+    // 1️⃣  Main message block
+    const mainMsg = {
+      reasoning_language: reasoningLanguage ? reasoningLanguage : 'English',
+      user: q.question,
+      analysis: includeCOT && q.cot ? `${q.cot}` : null,
+      final: q.answer
+    };
+    if (systemPrompt) {
+      mainMsg.developer = systemPrompt;
+    }
+    messages.push(mainMsg);
+
+    // 2️⃣  Optional system prompt
+    if (systemPrompt) {
+      messages.push({
+        role: 'system',
+        content: systemPrompt,
+        thinking: null
+      });
+    }
+
+    // 3️⃣  User message
+    messages.push({
+      role: 'user',
+      content: q.question,
+      thinking: null
+    });
+
+    // 4️⃣  Assistant message
+    messages.push({
+      role: 'assistant',
+      content: q.answer,
+      thinking: includeCOT && q.cot ? `${q.cot}` : null
+    });
+
+    return { messages };
+  });
+} else if (formatType === 'custom' && customFields) {
     return questions.map(q => {
       const item = {
         [customFields.questionField]: q.question,

--- a/app/api/projects/[projectId]/llamaFactory/generate/route.js
+++ b/app/api/projects/[projectId]/llamaFactory/generate/route.js
@@ -7,7 +7,7 @@ import { getDatasets } from '@/lib/db/datasets';
 export async function POST(request, { params }) {
   try {
     const { projectId } = params;
-    const { formatType, systemPrompt, confirmedOnly, includeCOT } = await request.json();
+    const { formatType, systemPrompt, confirmedOnly, includeCOT, reasoningLanguage } = await request.json();
 
     if (!projectId) {
       return NextResponse.json({ error: 'The project ID cannot be empty' }, { status: 400 });
@@ -19,6 +19,7 @@ export async function POST(request, { params }) {
     const configPath = path.join(projectPath, 'dataset_info.json');
     const alpacaPath = path.join(projectPath, 'alpaca.json');
     const sharegptPath = path.join(projectPath, 'sharegpt.json');
+    const multilingualThinkingPath = path.join(projectPath, 'multilingual-thinking.json');
 
     // 获取数据集
     let datasets = await getDatasets(projectId, !!confirmedOnly);
@@ -47,7 +48,21 @@ export async function POST(request, { params }) {
           assistant_tag: 'assistant',
           system_tag: 'system'
         }
-      }
+      },
+      [`[Easy Dataset] [${projectId}] multilingual-thinking`]: {
+        file_name: 'multilingual-thinking.json',
+        formatting: 'multilingual-thinking',
+        columns: {
+          messages: 'messages'
+        },
+        tags: {
+          role_tag: 'role',
+          content_tag: 'content',
+          user_tag: 'user',
+          assistant_tag: 'assistant',
+          system_tag: 'system'
+        }
+      }      
     };
 
     // 生成数据文件
@@ -76,18 +91,49 @@ export async function POST(request, { params }) {
       });
       return { messages };
     });
+    const multilingualThinkingData = datasets.map(({ question, answer, cot }) => ({
+      reasoning_language: reasoningLanguage ? reasoningLanguage : 'English',
+      developer: systemPrompt ? systemPrompt : '',                     // system prompt (may be empty)
+      user: question,
+      analysis: includeCOT && cot ? cot : null,    // null if no COT
+      final: answer,
+      messages: [
+        {
+          content: systemPrompt ? systemPrompt : '',
+          role: 'system',
+          thinking: null
+        },
+        {
+          content: question,
+          role: 'user',
+          thinking: null
+        },
+        {
+          content: answer,
+          role: 'assistant',
+          thinking: includeCOT && cot ? cot : null
+        }
+      ]
+    }));
+
+    const multilingualThinkingLines = multilingualThinkingData
+      .map(item => JSON.stringify(item, null, 2))
+      .join('\n');
+
+    await fs.promises.writeFile(multilingualThinkingPath, multilingualThinkingLines, 'utf8');    
 
     // 写入文件
     await fs.promises.writeFile(configPath, JSON.stringify(config, null, 2));
     await fs.promises.writeFile(alpacaPath, JSON.stringify(alpacaData, null, 2));
     await fs.promises.writeFile(sharegptPath, JSON.stringify(sharegptData, null, 2));
-
+ 
     return NextResponse.json({
       success: true,
       configPath,
       files: [
         { path: alpacaPath, format: 'alpaca' },
-        { path: sharegptPath, format: 'sharegpt' }
+        { path: sharegptPath, format: 'sharegpt' },
+        { path: multilingualThinkingPath, format: 'multilingual-thinking' },
       ]
     });
   } catch (error) {
@@ -95,3 +141,5 @@ export async function POST(request, { params }) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }
+
+

--- a/app/projects/[projectId]/datasets/hooks/useDatasetExport.js
+++ b/app/projects/[projectId]/datasets/hooks/useDatasetExport.js
@@ -144,6 +144,32 @@ const useDatasetExport = projectId => {
 
         return { messages };
       });
+    } else if (exportOptions.formatType === 'multilingualthinking') {
+      // 產生符合「Multilingual‑Thinking」的 JSON 結構
+      formattedData = dataToExport.map(({ question, answer, cot }) => ({
+        reasoning_language: exportOptions.reasoningLanguage ? exportOptions.reasoningLanguage : 'English',
+        developer: exportOptions.systemPrompt || '',
+        user: question,
+        analysis: exportOptions.includeCOT && cot ? cot : null,
+        final: answer,
+        messages: [
+          {
+            content: exportOptions.systemPrompt|| '',          
+            role: 'system',
+            thinking: null      
+          },       
+          {
+            content: question,          
+            role: 'user',
+            thinking: null
+          },
+          {
+            content: answer,
+            role: 'assistant',          
+            thinking: exportOptions.includeCOT && cot ? cot : null
+          }
+        ]
+      }));
     } else if (exportOptions.formatType === 'custom') {
       // 处理自定义格式
       const { questionField, answerField, cotField, includeLabels, includeChunk, questionOnly } =
@@ -198,6 +224,7 @@ const useDatasetExport = projectId => {
               // 处理包含逗号、换行符或双引号的字段
               let field = item[header]?.toString() || '';
               if (exportOptions.formatType === 'sharegpt') field = JSON.stringify(item[header]);
+              if (exportOptions.formatType === 'multilingualthinking') field = JSON.stringify(item[header]);
               if (field.includes(',') || field.includes('\n') || field.includes('"')) {
                 field = `"${field.replace(/"/g, '""')}"`;
               }
@@ -218,10 +245,19 @@ const useDatasetExport = projectId => {
     const blob = new Blob([content], { type: mimeType || 'application/json' });
 
     // 创建下载链接
+    // Determine a human‑readable suffix based on the selected format type
+    const formatSuffixMap = {
+      alpaca: 'alpaca',
+      'multilingual-thinking': 'multilingual-thinking',
+      sharegpt: 'sharegpt',
+      custom: 'custom',
+    };
+
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    const formatSuffix = exportOptions.formatType === 'alpaca' ? 'alpaca' : 'sharegpt';
+    // const formatSuffix = exportOptions.formatType === 'alpaca' ? 'alpaca' : 'multilingual-thinking';
+    const formatSuffix = formatSuffixMap[exportOptions.formatType] || exportOptions.formatType;
     const balanceSuffix = exportOptions.balanceMode ? '-balanced' : '';
     const dateStr = new Date().toISOString().slice(0, 10);
     a.download = `datasets-${projectId}-${formatSuffix}${balanceSuffix}-${dateStr}.${fileExtension}`;

--- a/components/ExportDatasetDialog.js
+++ b/components/ExportDatasetDialog.js
@@ -12,6 +12,7 @@ const ExportDatasetDialog = ({ open, onClose, onExport, projectId }) => {
   const { t } = useTranslation();
   const [formatType, setFormatType] = useState('alpaca');
   const [systemPrompt, setSystemPrompt] = useState('');
+  const [reasoningLanguage, setReasoningLanguage] = useState('');
   const [confirmedOnly, setConfirmedOnly] = useState(false);
   const [fileFormat, setFileFormat] = useState('json');
   const [includeCOT, setIncludeCOT] = useState(true);
@@ -47,6 +48,12 @@ const ExportDatasetDialog = ({ open, onClose, onExport, projectId }) => {
         questionField: 'content',
         answerField: 'content'
       });
+    } else if (event.target.value === 'multilingual-thinking') {
+      setCustomFields({
+        ...customFields,
+        questionField: 'content',
+        answerField: 'content'
+      });
     } else if (event.target.value === 'custom') {
       // 自定义格式保持当前值
     }
@@ -56,6 +63,9 @@ const ExportDatasetDialog = ({ open, onClose, onExport, projectId }) => {
     setSystemPrompt(event.target.value);
   };
 
+  const handleReasoningLanguageChange = event => {
+    setReasoningLanguage(event.target.value);
+  };
   const handleConfirmedOnlyChange = event => {
     setConfirmedOnly(event.target.checked);
   };
@@ -107,6 +117,7 @@ const ExportDatasetDialog = ({ open, onClose, onExport, projectId }) => {
     onExport({
       formatType,
       systemPrompt,
+      reasoningLanguage,
       confirmedOnly,
       fileFormat,
       includeCOT,
@@ -144,6 +155,7 @@ const ExportDatasetDialog = ({ open, onClose, onExport, projectId }) => {
             fileFormat={fileFormat}
             formatType={formatType}
             systemPrompt={systemPrompt}
+            reasoningLanguage={reasoningLanguage}
             confirmedOnly={confirmedOnly}
             includeCOT={includeCOT}
             customFields={customFields}
@@ -152,6 +164,7 @@ const ExportDatasetDialog = ({ open, onClose, onExport, projectId }) => {
             handleFileFormatChange={handleFileFormatChange}
             handleFormatChange={handleFormatChange}
             handleSystemPromptChange={handleSystemPromptChange}
+            handleReasoningLanguageChange={handleReasoningLanguageChange}
             handleConfirmedOnlyChange={handleConfirmedOnlyChange}
             handleIncludeCOTChange={handleIncludeCOTChange}
             handleCustomFieldChange={handleCustomFieldChange}
@@ -170,10 +183,12 @@ const ExportDatasetDialog = ({ open, onClose, onExport, projectId }) => {
           <LlamaFactoryTab
             projectId={projectId}
             systemPrompt={systemPrompt}
+            reasoningLanguage={reasoningLanguage}
             confirmedOnly={confirmedOnly}
             includeCOT={includeCOT}
             formatType={formatType}
             handleSystemPromptChange={handleSystemPromptChange}
+            handleReasoningLanguageChange={handleReasoningLanguageChange}
             handleConfirmedOnlyChange={handleConfirmedOnlyChange}
             handleIncludeCOTChange={handleIncludeCOTChange}
           />
@@ -184,12 +199,14 @@ const ExportDatasetDialog = ({ open, onClose, onExport, projectId }) => {
           <HuggingFaceTab
             projectId={projectId}
             systemPrompt={systemPrompt}
+            reasoningLanguage={reasoningLanguage}
             confirmedOnly={confirmedOnly}
             includeCOT={includeCOT}
             formatType={formatType}
             fileFormat={fileFormat}
             customFields={customFields}
             handleSystemPromptChange={handleSystemPromptChange}
+            handleReasoningLanguageChange={handleReasoningLanguageChange}
             handleConfirmedOnlyChange={handleConfirmedOnlyChange}
             handleIncludeCOTChange={handleIncludeCOTChange}
           />

--- a/components/export/HuggingFaceTab.js
+++ b/components/export/HuggingFaceTab.js
@@ -24,12 +24,14 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 const HuggingFaceTab = ({
   projectId,
   systemPrompt,
+  reasoningLanguage,
   confirmedOnly,
   includeCOT,
   formatType,
   fileFormat,
   customFields,
   handleSystemPromptChange,
+  handleReasoningLanguageChange,
   handleConfirmedOnlyChange,
   handleIncludeCOTChange
 }) => {
@@ -91,6 +93,7 @@ const HuggingFaceTab = ({
           isPrivate,
           formatType,
           systemPrompt,
+          reasoningLanguage,
           confirmedOnly,
           includeCOT,
           fileFormat,
@@ -195,7 +198,23 @@ const HuggingFaceTab = ({
             variant="outlined"
           />
         </Box>
-
+      {/* Reasoning language – only for multilingual‑thinking */}
+      {formatType === 'multilingualthinking' && (
+      <Box sx={{ mb: 3 }}>
+      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+      {t('export.reasoningLanguage')}
+      </Typography>
+      <TextField
+        fullWidth
+        rows={3}
+        multiline
+        variant="outlined"
+        placeholder={t('export.reasoningLanguage')}
+        value={reasoningLanguage}
+        onChange={handleReasoningLanguageChange}
+      />
+      </Box>
+     )}
         <Box sx={{ display: 'flex', flexDirection: 'row', gap: 4 }}>
           <FormControlLabel
             control={<Checkbox checked={confirmedOnly} onChange={handleConfirmedOnlyChange} />}

--- a/components/export/LlamaFactoryTab.js
+++ b/components/export/LlamaFactoryTab.js
@@ -19,10 +19,12 @@ import CheckIcon from '@mui/icons-material/Check';
 const LlamaFactoryTab = ({
   projectId,
   systemPrompt,
+  reasoningLanguage,
   confirmedOnly,
   includeCOT,
   formatType,
   handleSystemPromptChange,
+  handleReasoningLanguageChange,
   handleConfirmedOnlyChange,
   handleIncludeCOTChange
 }) => {
@@ -73,6 +75,7 @@ const LlamaFactoryTab = ({
         body: JSON.stringify({
           formatType,
           systemPrompt,
+          reasoningLanguage,
           confirmedOnly,
           includeCOT
         })
@@ -112,7 +115,23 @@ const LlamaFactoryTab = ({
           variant="outlined"
         />
       </Box>
-
+      {/* Reasoning language – only for multilingual‑thinking */}
+      {formatType === 'multilingualthinking' && (
+      <Box sx={{ mb: 3 }}>
+      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+      {t('export.reasoningLanguage')}
+      </Typography>
+      <TextField
+        fullWidth
+        rows={3}
+        multiline
+        variant="outlined"
+        placeholder={t('export.reasoningLanguage')}
+        value={reasoningLanguage}
+        onChange={handleReasoningLanguageChange}
+      />
+      </Box>
+     )}
       <Box sx={{ mb: 2, display: 'flex', flexDirection: 'row', gap: 4 }}>
         <FormControlLabel
           control={<Checkbox checked={confirmedOnly} onChange={handleConfirmedOnlyChange} />}

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -396,6 +396,7 @@
     "fileFormat": "File Format",
     "systemPrompt": "System Prompt",
     "systemPromptPlaceholder": "Please enter system prompt...",
+    "ReasoninglanguagePlaceholder": "Please enter Reasoning language : English or Chinese or others",
     "onlyConfirmed": "Only export confirmed data",
     "example": "Format Example",
     "confirmExport": "Confirm Export",
@@ -403,7 +404,9 @@
     "cotDescription": "Includes the reasoning process before the final answer",
     "customFormat": "Custom Format",
     "customFormatSettings": "Custom Format Settings",
-    "questionFieldName": "Question Field Name"
+    "questionFieldName": "Question Field Name",
+    "multilingualThinkingFormat": "Multilingual‑Thinking",
+    "Reasoninglanguage": "Reasoning language"
   },
   "import": {
     "title": "Import",

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -396,6 +396,8 @@
     "fileFormat": "文件格式",
     "systemPrompt": "系统提示词",
     "systemPromptPlaceholder": "请输入系统提示词...",
+    "ReasoninglanguagePlaceholder": "请输入Reasoning language : English or Chinese or others",
+    "Reasoninglanguage": "推理语言",
     "onlyConfirmed": "仅导出已确认数据",
     "example": "格式示例",
     "confirmExport": "确认导出",
@@ -428,7 +430,8 @@
     "viewOnHuggingFace": "在 HuggingFace查看",
     "noTokenWarning": "未找到 HuggingFace 令牌。请在项目设置中配置令牌。",
     "goToSettings": "前往设置",
-    "tokenHelp": "您可以从HuggingFace设置页面获取令牌"
+    "tokenHelp": "您可以从HuggingFace设置页面获取令牌",
+    "multilingualThinkingFormat": "Multilingual‑Thinking"    
   },
   "datasets": {
     "loadingDataset": "正在加载数据集详情...",


### PR DESCRIPTION
* HuggingFaceH4/Multilingual-Thinking use for gpt-oss LLM fine-tuning dataset with unsloth tool.

### 变更类型- [ *] 新功能（feat）

- [ ] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）

### 变更描述- 简要说明修改内容（关联Issue：#123）
1. The application now fully supports the HuggingFaceH4/Multilingual-Thinking export format, both on the client-side export dialog and on the server-side generation routes. Add the export HuggingFaceH4/Multilingual-Thinking dataset format.
2. Exported file names now reflect the actual format type (alpaca, sharegpt, multilingual-thinking, or custom) via a lookup table, instead of being hard-coded.
3. Users can specify a reasoning language when exporting in the Multilingual-Thinking format.
4. UI and documentation have been updated to reflect the new format and options.

### 文档更新- [* ] README.md

- [ ] 贡献指南
- [ ] 接口文档（如有）
