### PR TITLE
fix: persist pagination state in dataset list (#594)

### DIFF
--- a/app/projects/[projectId]/datasets/hooks/useDatasetFilters.js
+++ b/app/projects/[projectId]/datasets/hooks/useDatasetFilters.js
@@ -18,6 +18,8 @@ export function useDatasetFilters(projectId) {
   const [filterChunkName, setFilterChunkName] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchField, setSearchField] = useState('question');
+  const [page, setPage] = useState(1);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
   const [isInitialized, setIsInitialized] = useState(false);
 
   // 从 localStorage 恢复筛选条件
@@ -36,6 +38,8 @@ export function useDatasetFilters(projectId) {
           setFilterChunkName(filters.filterChunkName || '');
           setSearchQuery(filters.searchQuery || '');
           setSearchField(filters.searchField || 'question');
+          setPage(filters.page || 1);
+          setRowsPerPage(filters.rowsPerPage || 10);
         }
       } catch (error) {
         console.error('恢复筛选条件失败:', error);
@@ -57,7 +61,9 @@ export function useDatasetFilters(projectId) {
           filterNoteKeyword,
           filterChunkName,
           searchQuery,
-          searchField
+          searchField,
+          page,
+          rowsPerPage
         };
         localStorage.setItem(`datasets-filters-${projectId}`, JSON.stringify(filters));
       } catch (error) {
@@ -75,6 +81,8 @@ export function useDatasetFilters(projectId) {
     filterChunkName,
     searchQuery,
     searchField,
+    page,
+    rowsPerPage,
     isInitialized
   ]);
 
@@ -91,6 +99,8 @@ export function useDatasetFilters(projectId) {
     setFilterChunkName('');
     setSearchQuery('');
     setSearchField('question');
+    setPage(1);
+    setRowsPerPage(10);
   };
 
   /**
@@ -144,6 +154,11 @@ export function useDatasetFilters(projectId) {
     setSearchQuery,
     searchField,
     setSearchField,
+    // 分页状态
+    page,
+    setPage,
+    rowsPerPage,
+    setRowsPerPage,
     // 初始化状态
     isInitialized,
     // 工具方法

--- a/app/projects/[projectId]/datasets/page.js
+++ b/app/projects/[projectId]/datasets/page.js
@@ -34,8 +34,6 @@ export default function DatasetsPage({ params }) {
     batch: false,
     deleting: false
   });
-  const [page, setPage] = useState(1);
-  const [rowsPerPage, setRowsPerPage] = useState(10);
   const [exportDialog, setExportDialog] = useState({ open: false });
   const [importDialog, setImportDialog] = useState({ open: false });
   const [selectedIds, setselectedIds] = useState([]);
@@ -63,6 +61,10 @@ export default function DatasetsPage({ params }) {
     setSearchQuery,
     searchField,
     setSearchField,
+    page,
+    setPage,
+    rowsPerPage,
+    setRowsPerPage,
     isInitialized,
     getActiveFilterCount
   } = useDatasetFilters(projectId);
@@ -176,7 +178,7 @@ export default function DatasetsPage({ params }) {
   }, [projectId, page, rowsPerPage, debouncedSearchQuery, searchField, isInitialized]);
 
   // 处理页码变化
-  const handlePageChange = (event, newPage) => {
+  const handlePageChange = (_event, newPage) => {
     // MUI TablePagination 的页码从 0 开始，而我们的 API 从 1 开始
     setPage(newPage + 1);
   };


### PR DESCRIPTION
  ## Description
  Fix the pagination state reset issue when navigating back from dataset
  details page.

  ## Changes
  - Add `page` and `rowsPerPage` to `useDatasetFilters` hook
  - Save pagination state to localStorage
  - Restore pagination settings when component remounts

  ## Testing
  - Set rows per page to 20 and navigate to page 3
  - Click into a dataset detail page
  - Navigate back using browser back button
  - Verify pagination settings are preserved (still on page 3 with 20 rows
  per page)

  ## Related Issue
  Fixes #594

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing
  functionality to not work as expected)

  ## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have tested my changes locally
  - [x] The changes fix the issue described in #594