### PR TITLE
fix: Add Turkish language support in prompt loader

### DIFF
--- a/lib/llm/common/prompt-loader.js
+++ b/lib/llm/common/prompt-loader.js
@@ -38,6 +38,9 @@ export function getPromptKey(language, baseKey) {
   if (language === 'en') {
     return `${baseKey}_EN`;
   }
+  if (language === 'tr') {
+    return `${baseKey}_TR`;
+  }
   return baseKey;
 }
 
@@ -47,7 +50,13 @@ export function getPromptKey(language, baseKey) {
  * @returns {string} 语言
  */
 export function getLanguageFromKey(promptKey) {
-  return promptKey.endsWith('_EN') ? 'en' : 'zh-CN';
+  if (promptKey.endsWith('_EN')) {
+    return 'en';
+  }
+  if (promptKey.endsWith('_TR')) {
+    return 'tr';
+  }
+  return 'zh-CN';
 }
 
 /**
@@ -62,7 +71,14 @@ export function getLanguageFromKey(promptKey) {
  */
 export async function processPrompt(language, promptType, baseKey, defaultPrompts, params = {}, projectId = null) {
   const promptKey = getPromptKey(language, baseKey);
-  const defaultPrompt = language === 'en' ? defaultPrompts.en : defaultPrompts.zh;
+  let defaultPrompt;
+  if (language === 'en') {
+    defaultPrompt = defaultPrompts.en;
+  } else if (language === 'tr') {
+    defaultPrompt = defaultPrompts.tr;
+  } else {
+    defaultPrompt = defaultPrompts.zh;
+  }
   const langCode = getLanguageFromKey(promptKey);
 
   let prompt = defaultPrompt;


### PR DESCRIPTION
## Recent Fix (Nov 24, 2025)

Fixed a critical bug where **Turkish prompts were showing Chinese content** instead of Turkish.

**Root Cause:** 
The `prompt-loader.js` file only handled 'en' and 'zh' languages, missing Turkish support.

**Solution:**
Updated `lib/llm/common/prompt-loader.js`:
- Added 'tr' case in `getPromptKey()` function
- Added 'tr' case in `getLanguageFromKey()` function  
- Added 'tr' case in `processPrompt()` function

**Commit:** `553347a`

Turkish language now works correctly! 🇹🇷