### PR TITLE
兼容 OpenAI-compatible v1 接口并修复 vLLM 场景下的响应解析异常

### DIFF
--- a/lib/llm/core/index.js
+++ b/lib/llm/core/index.js
@@ -12,6 +12,50 @@ const ZhiPuClient = require('./providers/zhipu'); // 导入 ZhiPuClient
 const OpenRouterClient = require('./providers/openrouter');
 const AlibailianClient = require('./providers/alibailian'); // 导入 AlibailianClient
 
+function normalizeLlmText(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => normalizeLlmText(item)).filter(Boolean).join('');
+  }
+
+  if (typeof value === 'object') {
+    if (typeof value.text === 'string') {
+      return value.text;
+    }
+
+    if (typeof value.content === 'string') {
+      return value.content;
+    }
+
+    if (Array.isArray(value.content)) {
+      return normalizeLlmText(value.content);
+    }
+
+    if (Array.isArray(value.parts)) {
+      return normalizeLlmText(value.parts);
+    }
+
+    if (typeof value.reasoningText === 'string') {
+      return value.reasoningText;
+    }
+
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+}
+
 class LLMClient {
   /**
    * 创建 LLM 客户端实例
@@ -185,13 +229,13 @@ class LLMClient {
   // 获取模型响应
   async getResponse(prompt, options = {}) {
     const llmRes = await this.chat(prompt, options);
-    return llmRes.text || llmRes.response.messages || '';
+    return normalizeLlmText(llmRes.text || llmRes.response?.messages || '');
   }
 
   // 提取答案和思维链
   extractAnswerAndCOT(llmRes) {
-    let answer = llmRes.text || '';
-    let cot = llmRes.reasoning || '';
+    let answer = normalizeLlmText(llmRes?.text || '');
+    let cot = normalizeLlmText(llmRes?.reasoning || '');
     if ((answer && answer.startsWith('<think>')) || answer.startsWith('<thinking>')) {
       cot = extractThinkChain(answer);
       answer = extractAnswer(answer);
@@ -200,10 +244,10 @@ class LLMClient {
       llmRes.response.body.choices[0].message.reasoning_content
     ) {
       if (llmRes.response.body.choices[0].message.reasoning_content) {
-        cot = llmRes.response.body.choices[0].message.reasoning_content;
+        cot = normalizeLlmText(llmRes.response.body.choices[0].message.reasoning_content);
       }
       if (llmRes.response.body.choices[0].message.content) {
-        answer = llmRes.response.body.choices[0].message.content;
+        answer = normalizeLlmText(llmRes.response.body.choices[0].message.content);
       }
     }
     if (answer.startsWith('\n\n')) {

--- a/lib/llm/core/providers/base.js
+++ b/lib/llm/core/providers/base.js
@@ -1,10 +1,39 @@
 import { generateText, streamText } from 'ai';
 
+function isOfficialOpenAIEndpoint(endpoint = '') {
+  const normalizedEndpoint = String(endpoint || '').trim().toLowerCase();
+
+  if (!normalizedEndpoint) {
+    return false;
+  }
+
+  try {
+    const { hostname } = new URL(normalizedEndpoint);
+    return hostname === 'api.openai.com' || hostname.endsWith('.openai.com');
+  } catch {
+    return normalizedEndpoint.includes('api.openai.com');
+  }
+}
+
 function checkOpenAIModel(endpoint, model) {
-  // if (endpoint.includes('api.openai.com')) {
-  return ['gpt-5', 'gpt-4', 'o1'].find(m => model.startsWith(m));
-  // }
-  return false;
+  if (!isOfficialOpenAIEndpoint(endpoint)) {
+    return false;
+  }
+
+  const normalizedModel = String(model || '');
+  return ['gpt-5', 'gpt-4', 'o1'].find(m => normalizedModel.startsWith(m));
+}
+
+function resolveModelId(model, fallbackModel) {
+  if (typeof model === 'function') {
+    return String(model.modelId || model.modelName || fallbackModel || '');
+  }
+
+  if (model && typeof model === 'object') {
+    return String(model.modelId || model.modelName || fallbackModel || '');
+  }
+
+  return String(fallbackModel || '');
 }
 
 class BaseClient {
@@ -72,7 +101,7 @@ class BaseClient {
    */
   async chatStreamAPI(messages, options) {
     const model = this._getModel();
-    const modelName = typeof model === 'function' ? model.modelName : this.model;
+    const modelName = resolveModelId(model, this.model);
     const isOpenAIModel = checkOpenAIModel(this.endpoint, this.model);
     const maxTokens = options.max_tokens || this.modelConfig.max_tokens;
     const payload = {
@@ -92,17 +121,15 @@ class BaseClient {
 
     try {
       // 发起流式请求
-      const response = await fetch(
-        `${this.endpoint.endsWith('/') ? this.endpoint : `${this.endpoint}/`}chat/completions`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.apiKey}`
-          },
-          body: JSON.stringify(payload)
-        }
-      );
+      const endpoint = String(this.endpoint || '').trim();
+      const response = await fetch(`${endpoint.endsWith('/') ? endpoint : `${endpoint}/`}chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`
+        },
+        body: JSON.stringify(payload)
+      });
 
       if (!response.ok) {
         const errorText = await response.text();

--- a/lib/llm/core/providers/ollama.js
+++ b/lib/llm/core/providers/ollama.js
@@ -38,7 +38,7 @@ class OllamaClient extends BaseClient {
 
   async chatStreamAPI(messages, options) {
     const model = this._getModel();
-    const modelName = typeof model === 'function' ? model.modelName : this.model;
+    const modelName = model?.modelId || model?.modelName || this.model;
 
     // 构建符合 Ollama API 的请求数据
     const payload = {
@@ -52,13 +52,13 @@ class OllamaClient extends BaseClient {
       }
     };
 
-    if (this.endpoint.endsWith('/api')) {
+    if (String(this.endpoint).endsWith('/api')) {
       this.endpoint = this.endpoint.slice(0, -4);
     }
 
     try {
       // 发起流式请求
-      const response = await fetch(`${this.endpoint.endsWith('/') ? this.endpoint : `${this.endpoint}/`}api/chat`, {
+      const response = await fetch(`${String(this.endpoint).endsWith('/') ? this.endpoint : `${this.endpoint}/`}api/chat`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/lib/llm/core/providers/openai.js
+++ b/lib/llm/core/providers/openai.js
@@ -1,13 +1,42 @@
 import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import BaseClient from './base.js';
+
+function isOfficialOpenAIEndpoint(endpoint = '') {
+  const normalizedEndpoint = String(endpoint || '').trim().toLowerCase();
+
+  if (!normalizedEndpoint) {
+    return false;
+  }
+
+  try {
+    const { hostname } = new URL(normalizedEndpoint);
+    return hostname === 'api.openai.com' || hostname.endsWith('.openai.com');
+  } catch {
+    return normalizedEndpoint.includes('api.openai.com');
+  }
+}
+
+function getCompatibleProviderName(provider = '') {
+  return String(provider || 'openai-compatible')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-') || 'openai-compatible';
+}
 
 class OpenAIClient extends BaseClient {
   constructor(config) {
     super(config);
-    this.openai = createOpenAI({
-      baseURL: this.endpoint,
-      apiKey: this.apiKey
-    });
+    this.openai = isOfficialOpenAIEndpoint(this.endpoint)
+      ? createOpenAI({
+          baseURL: this.endpoint,
+          apiKey: this.apiKey
+        })
+      : createOpenAICompatible({
+          name: getCompatibleProviderName(this.provider),
+          baseURL: this.endpoint,
+          apiKey: this.apiKey
+        });
   }
 
   _getModel() {


### PR DESCRIPTION
> ### 变更类型- [ ] 新功能（feat）
> * [x]  修复（fix）
> * [ ]  文档（docs）
> * [ ]  重构（refactor）
**背景**
在 easy-dataset 中接入 vLLM 提供的 OpenAI-compatible 模型服务时，如果该服务只支持 v1 接口，当前实现会在调用阶段报错，导致模型无法正常用于清洗、问答生成和 Playground 等流程。

**问题表现**
使用非官方 OpenAI 兼容端点时，出现以下两类问题：

模型调用报错，提示不支持 v1 版本
[Unsupported model version v1 for provider "openai.chat"]

部分流程在响应解析阶段报错
TypeError: endsWith is not a function

**问题原因**
根因主要有三点：

当前 OpenAI provider 默认走官方 OpenAI 适配器。
对于 vLLM 这类仅提供 OpenAI-compatible v1 接口的服务，这种接法不兼容。

现有实现对 OpenAI 模型做了一些官方接口专用参数处理。
这些逻辑原本默认作用于所有 OpenAI 风格端点，但对非官方兼容服务并不总是成立。

现有代码默认把模型元信息和 LLM 返回内容都当作字符串处理。
在 AI SDK 新的返回结构下，模型对象可能使用 modelId，响应内容也可能是对象或数组，最终导致 startsWith / endsWith 一类字符串操作报错。

**解决方案**
本 PR 只做最小兼容性补丁，尽量不改变原有逻辑：

对 OpenAI provider 增加端点识别。
如果是官方 OpenAI 域名，继续使用原有官方 provider；如果是非官方 OpenAI-compatible 端点，则切换到 compatible provider。

将 OpenAI 专属参数逻辑限制到真正的官方 OpenAI 端点。
避免把官方接口特有行为错误应用到 vLLM 等兼容服务上。

在流式 API 请求处补充 modelId 兼容。
兼容 AI SDK 新模型对象结构，避免仍然只依赖旧的 modelName。

在少量必要位置增加字符串兜底。
对 endpoint、text、reasoning、message.content 等字段做局部归一化，避免数组或对象参与字符串方法调用而报错。

**影响范围**
这次修改主要影响以下场景：

使用 vLLM / OpenAI-compatible 服务作为模型源
数据清洗流程中的带思维链响应解析
流式输出与 Playground 调用链路
对官方 OpenAI 端点的原有行为保持不变。

**预期收益**
合并后，easy-dataset 可以正常接入只提供 OpenAI-compatible v1 接口的模型服务，并且在 AI SDK 新返回结构下避免因类型假设过强而导致的解析异常。
