### PR TITLE
fix: i18n support for Dataset Square - category filtering broken for non-Chinese languages

### DIFF
--- a/components/dataset-square/DatasetSearchBar.js
+++ b/components/dataset-square/DatasetSearchBar.js
@@ -22,6 +22,7 @@ import LaunchIcon from '@mui/icons-material/Launch';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
 import sites from '@/constant/sites.json';
 import { useTranslation } from 'react-i18next';
+import { getSiteField } from '@/lib/util/sites-i18n';
 
 export function DatasetSearchBar() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -30,7 +31,7 @@ export function DatasetSearchBar() {
   const searchRef = useRef(null);
   const suggestionsRef = useRef(null);
   const theme = useTheme();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   // 从 localStorage 加载最近搜索
   useEffect(() => {
@@ -238,7 +239,7 @@ export function DatasetSearchBar() {
                                   <TravelExploreIcon fontSize="small" />
                                 </Avatar>
                                 <Typography>
-                                  {t('datasetSquare.searchVia')} <strong>{site.name}</strong> Search
+                                  {t('datasetSquare.searchVia')} <strong>{getSiteField(site, 'name', i18n.language)}</strong> Search
                                 </Typography>
                               </Box>
                               <Box sx={{ display: 'flex', alignItems: 'center' }}>

--- a/components/dataset-square/DatasetSiteCard.js
+++ b/components/dataset-square/DatasetSiteCard.js
@@ -4,14 +4,18 @@ import { Card, CardActionArea, CardContent, CardMedia, Typography, Box, Chip, us
 import LaunchIcon from '@mui/icons-material/Launch';
 import StorageIcon from '@mui/icons-material/Storage';
 import { useTranslation } from 'react-i18next';
+import { getSiteField } from '@/lib/util/sites-i18n';
 
 export function DatasetSiteCard({ site }) {
-  const { name, link, description, image, labels } = site;
+  const { link, image, labels } = site;
   const theme = useTheme();
+  const { t, i18n } = useTranslation();
+
+  const name = getSiteField(site, 'name', i18n.language);
+  const description = getSiteField(site, 'description', i18n.language);
 
   // 处理图片路径，如果没有图片则使用默认图片
   const imageUrl = image || `/imgs/default-dataset.png`;
-  const { t } = useTranslation();
 
   // 处理卡片点击
   const handleCardClick = () => {
@@ -156,7 +160,7 @@ export function DatasetSiteCard({ site }) {
                 {labels.map((label, index) => (
                   <Chip
                     key={index}
-                    label={label}
+                    label={t(`datasetSquare.labels.${label}`, label)}
                     size="small"
                     sx={{
                       borderRadius: 1,

--- a/components/dataset-square/DatasetSiteList.js
+++ b/components/dataset-square/DatasetSiteList.js
@@ -9,20 +9,21 @@ import { DatasetSiteCard } from './DatasetSiteCard';
 import sites from '@/constant/sites.json';
 import { useTranslation } from 'react-i18next';
 
+// Locale-neutral category keys for filtering (must match label keys in sites.json)
+const CATEGORIES = {
+  ALL: 'all',
+  POPULAR: 'popular',
+  CHINESE: 'chinese_resource',
+  ENGLISH: 'english_resource',
+  RESEARCH: 'research',
+  MULTIMODAL: 'multimodal'
+};
+
 export function DatasetSiteList() {
   const [loading, setLoading] = useState(true);
   const theme = useTheme();
   const { t } = useTranslation();
 
-  // 定义类别
-  const CATEGORIES = {
-    ALL: t('datasetSquare.categories.all'),
-    POPULAR: t('datasetSquare.categories.popular'),
-    CHINESE: t('datasetSquare.categories.chinese'),
-    ENGLISH: t('datasetSquare.categories.english'),
-    RESEARCH: t('datasetSquare.categories.research'),
-    MULTIMODAL: t('datasetSquare.categories.multimodal')
-  };
   const [activeCategory, setActiveCategory] = useState(CATEGORIES.ALL);
 
   // 模拟加载效果
@@ -43,18 +44,8 @@ export function DatasetSiteList() {
   const getFilteredSites = () => {
     if (activeCategory === CATEGORIES.ALL) {
       return sites;
-    } else if (activeCategory === CATEGORIES.POPULAR) {
-      return sites.filter(site => site.labels && site.labels.includes(t('datasetSquare.categories.popular')));
-    } else if (activeCategory === CATEGORIES.CHINESE) {
-      return sites.filter(site => site.labels && site.labels.includes(t('datasetSquare.categories.chinese')));
-    } else if (activeCategory === CATEGORIES.ENGLISH) {
-      return sites.filter(site => site.labels && site.labels.includes(t('datasetSquare.categories.english')));
-    } else if (activeCategory === CATEGORIES.RESEARCH) {
-      return sites.filter(site => site.labels && site.labels.includes(t('datasetSquare.categories.research')));
-    } else if (activeCategory === CATEGORIES.MULTIMODAL) {
-      return sites.filter(site => site.labels && site.labels.includes(t('datasetSquare.categories.multimodal')));
     }
-    return sites;
+    return sites.filter(site => site.labels && site.labels.includes(activeCategory));
   };
 
   const filteredSites = getFilteredSites();
@@ -109,20 +100,20 @@ export function DatasetSiteList() {
           >
             <Tab
               value={CATEGORIES.ALL}
-              label={CATEGORIES.ALL}
+              label={t('datasetSquare.categories.all')}
               icon={<StorageIcon fontSize="small" />}
               iconPosition="start"
             />
             <Tab
               value={CATEGORIES.POPULAR}
-              label={CATEGORIES.POPULAR}
+              label={t('datasetSquare.categories.popular')}
               icon={<StarIcon fontSize="small" />}
               iconPosition="start"
             />
-            <Tab value={CATEGORIES.CHINESE} label={CATEGORIES.CHINESE} />
-            <Tab value={CATEGORIES.ENGLISH} label={CATEGORIES.ENGLISH} />
-            <Tab value={CATEGORIES.RESEARCH} label={CATEGORIES.RESEARCH} />
-            <Tab value={CATEGORIES.MULTIMODAL} label={CATEGORIES.MULTIMODAL} />
+            <Tab value={CATEGORIES.CHINESE} label={t('datasetSquare.categories.chinese')} />
+            <Tab value={CATEGORIES.ENGLISH} label={t('datasetSquare.categories.english')} />
+            <Tab value={CATEGORIES.RESEARCH} label={t('datasetSquare.categories.research')} />
+            <Tab value={CATEGORIES.MULTIMODAL} label={t('datasetSquare.categories.multimodal')} />
           </Tabs>
         </Paper>
       </Box>
@@ -163,7 +154,7 @@ export function DatasetSiteList() {
 
                 {activeCategory !== CATEGORIES.ALL && (
                   <Chip
-                    label={t('datasetSquare.currentFilter', { category: activeCategory })}
+                    label={t('datasetSquare.currentFilter', { category: t(`datasetSquare.labels.${activeCategory}`, activeCategory) })}
                     size="small"
                     onDelete={() => setActiveCategory(CATEGORIES.ALL)}
                     sx={{ borderRadius: 1.5 }}

--- a/constant/sites.json
+++ b/constant/sites.json
@@ -1,286 +1,654 @@
 [
   {
-    "name": "HuggingFace开源数据集",
+    "name": {
+      "zh-CN": "HuggingFace开源数据集",
+      "en": "HuggingFace Open Datasets",
+      "tr": "HuggingFace Açık Veri Setleri"
+    },
     "link": "https://huggingface.co/datasets",
     "image": "/imgs/huggingface.png",
-    "description": "提供了丰富的开源数据集，涵盖多种领域和语言，支持自然语言处理、计算机视觉等多种任务。",
-    "labels": ["热门推荐", "多模态"]
+    "description": {
+      "zh-CN": "提供了丰富的开源数据集，涵盖多种领域和语言，支持自然语言处理、计算机视觉等多种任务。",
+      "en": "Offers a rich collection of open-source datasets covering multiple domains and languages, supporting NLP, computer vision, and more.",
+      "tr": "Birden fazla alan ve dili kapsayan, NLP, bilgisayar görüşü ve daha fazlasını destekleyen zengin bir açık kaynak veri seti koleksiyonu sunar."
+    },
+    "labels": ["popular", "multimodal"]
   },
   {
-    "name": "OpenDataLab开源数据集",
+    "name": {
+      "zh-CN": "OpenDataLab开源数据集",
+      "en": "OpenDataLab Open Datasets",
+      "tr": "OpenDataLab Açık Veri Setleri"
+    },
     "link": "https://opendatalab.com/",
     "image": "/imgs/opendatalab.png",
-    "description": "致力于收集和整理高质量的开源数据集，方便研究人员和开发者使用。",
-    "labels": ["热门推荐"]
+    "description": {
+      "zh-CN": "致力于收集和整理高质量的开源数据集，方便研究人员和开发者使用。",
+      "en": "Dedicated to collecting and organizing high-quality open-source datasets for researchers and developers.",
+      "tr": "Araştırmacılar ve geliştiriciler için yüksek kaliteli açık kaynak veri setleri toplamaya ve düzenlemeye adanmıştır."
+    },
+    "labels": ["popular"]
   },
   {
-    "name": "谷歌开源数据集",
+    "name": {
+      "zh-CN": "谷歌开源数据集",
+      "en": "Google Dataset Search",
+      "tr": "Google Veri Seti Arama"
+    },
     "link": "https://datasetsearch.research.google.com",
     "image": "/imgs/google.png",
-    "description": "谷歌提供的数据集搜索工具，可帮助用户找到来自不同来源的公开数据集。",
-    "labels": ["热门推荐", "英文资源"]
+    "description": {
+      "zh-CN": "谷歌提供的数据集搜索工具，可帮助用户找到来自不同来源的公开数据集。",
+      "en": "Google's dataset search tool helping users find public datasets from various sources.",
+      "tr": "Kullanıcıların çeşitli kaynaklardan açık veri setleri bulmasına yardımcı olan Google veri seti arama aracı."
+    },
+    "labels": ["popular", "english_resource"]
   },
   {
-    "name": "kaggle开源数据集",
+    "name": {
+      "zh-CN": "kaggle开源数据集",
+      "en": "Kaggle Open Datasets",
+      "tr": "Kaggle Açık Veri Setleri"
+    },
     "link": "https://www.kaggle.com/datasets",
     "image": "/imgs/kaggle.png",
-    "description": "Kaggle平台上的开源数据集，涉及各种领域和任务，常用于数据竞赛和实践。",
-    "labels": ["热门推荐", "英文资源"]
+    "description": {
+      "zh-CN": "Kaggle平台上的开源数据集，涉及各种领域和任务，常用于数据竞赛和实践。",
+      "en": "Open datasets on the Kaggle platform, covering various domains and tasks, commonly used for data competitions and practice.",
+      "tr": "Kaggle platformundaki açık veri setleri, çeşitli alanları ve görevleri kapsar, veri yarışmaları ve uygulama için yaygın olarak kullanılır."
+    },
+    "labels": ["popular", "english_resource"]
   },
   {
-    "name": "ModelScope开源数据集",
+    "name": {
+      "zh-CN": "ModelScope开源数据集",
+      "en": "ModelScope Open Datasets",
+      "tr": "ModelScope Açık Veri Setleri"
+    },
     "link": "https://modelscope.cn/datasets",
     "image": "/imgs/modelscope.png",
-    "description": "提供了多种开源数据集，支持模型的训练和评估，涵盖多个领域。",
-    "labels": ["中文资源"]
+    "description": {
+      "zh-CN": "提供了多种开源数据集，支持模型的训练和评估，涵盖多个领域。",
+      "en": "Provides various open-source datasets supporting model training and evaluation across multiple domains.",
+      "tr": "Birden fazla alanda model eğitimi ve değerlendirmesini destekleyen çeşitli açık kaynak veri setleri sunar."
+    },
+    "labels": ["chinese_resource"]
   },
   {
-    "name": "LUGE千言开源数据集",
+    "name": {
+      "zh-CN": "LUGE千言开源数据集",
+      "en": "LUGE Open Datasets",
+      "tr": "LUGE Açık Veri Setleri"
+    },
     "link": "https://www.luge.ai/",
     "image": "/imgs/lluga.png",
-    "description": "专注于中文领域的开源数据集，包括自然语言处理、语音识别等方向。",
-    "labels": ["中文资源"]
+    "description": {
+      "zh-CN": "专注于中文领域的开源数据集，包括自然语言处理、语音识别等方向。",
+      "en": "Focused on Chinese-language open datasets, including NLP, speech recognition, and more.",
+      "tr": "NLP, konuşma tanıma ve daha fazlasını içeren Çince odaklı açık veri setleri."
+    },
+    "labels": ["chinese_resource"]
   },
   {
-    "name": "GitHub开源数据集",
+    "name": {
+      "zh-CN": "GitHub开源数据集",
+      "en": "GitHub Awesome Public Datasets",
+      "tr": "GitHub Harika Açık Veri Setleri"
+    },
     "link": "https://github.com/awesomedata/awesome-public-datasets",
     "image": "/imgs/github.png",
-    "description": "在GitHub上整理的优秀的公开数据集资源，涉及多个领域和方向。",
-    "labels": ["热门推荐"]
+    "description": {
+      "zh-CN": "在GitHub上整理的优秀的公开数据集资源，涉及多个领域和方向。",
+      "en": "A curated list of awesome public datasets on GitHub, covering multiple domains and topics.",
+      "tr": "GitHub'da birden fazla alanı ve konuyu kapsayan seçilmiş açık veri setleri listesi."
+    },
+    "labels": ["popular"]
   },
   {
-    "name": "AWS亚马逊开源数据集",
+    "name": {
+      "zh-CN": "AWS亚马逊开源数据集",
+      "en": "AWS Open Data",
+      "tr": "AWS Açık Veri"
+    },
     "link": "https://registry.opendata.aws/",
     "image": "/imgs/aws.png",
-    "description": "提供了大量的公开数据集，涵盖多个领域，可在亚马逊云服务上直接访问和使用。",
-    "labels": ["英文资源"]
+    "description": {
+      "zh-CN": "提供了大量的公开数据集，涵盖多个领域，可在亚马逊云服务上直接访问和使用。",
+      "en": "Provides numerous public datasets across multiple domains, directly accessible on AWS cloud services.",
+      "tr": "AWS bulut hizmetlerinde doğrudan erişilebilen, birden fazla alanda çok sayıda açık veri seti sunar."
+    },
+    "labels": ["english_resource"]
   },
   {
-    "name": "TIANCHI天池开源数据集",
+    "name": {
+      "zh-CN": "TIANCHI天池开源数据集",
+      "en": "TIANCHI Open Datasets",
+      "tr": "TIANCHI Açık Veri Setleri"
+    },
     "link": "https://tianchi.aliyun.com/dataset/",
-    "description": "阿里云天池平台提供的开源数据集，涵盖多个领域的竞赛数据和公开数据。",
-    "labels": ["中文资源"]
+    "description": {
+      "zh-CN": "阿里云天池平台提供的开源数据集，涵盖多个领域的竞赛数据和公开数据。",
+      "en": "Open datasets from Alibaba Cloud's Tianchi platform, covering competition and public data across multiple domains.",
+      "tr": "Alibaba Cloud'un Tianchi platformundan, birden fazla alanda yarışma ve açık verileri kapsayan veri setleri."
+    },
+    "labels": ["chinese_resource"]
   },
   {
-    "name": "UCI开源数据集",
+    "name": {
+      "zh-CN": "UCI开源数据集",
+      "en": "UCI Machine Learning Repository",
+      "tr": "UCI Makine Öğrenmesi Deposu"
+    },
     "link": "https://archive.ics.uci.edu/datasets",
-    "description": "加州大学欧文分校提供的开源数据集，涵盖多个领域，常用于机器学习研究。",
-    "labels": ["研究数据", "英文资源"]
+    "description": {
+      "zh-CN": "加州大学欧文分校提供的开源数据集，涵盖多个领域，常用于机器学习研究。",
+      "en": "Open datasets from UC Irvine, covering multiple domains, widely used for machine learning research.",
+      "tr": "UC Irvine'dan birden fazla alanı kapsayan, makine öğrenmesi araştırmaları için yaygın olarak kullanılan açık veri setleri."
+    },
+    "labels": ["research", "english_resource"]
   },
   {
-    "name": "计算机视觉开源数据集",
+    "name": {
+      "zh-CN": "计算机视觉开源数据集",
+      "en": "Visual Data Discovery",
+      "tr": "Görsel Veri Keşfi"
+    },
     "link": "https://visualdata.io/discovery",
-    "description": "专注于计算机视觉领域的开源数据集，支持相关模型的训练和评估。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "专注于计算机视觉领域的开源数据集，支持相关模型的训练和评估。",
+      "en": "Open datasets focused on computer vision, supporting related model training and evaluation.",
+      "tr": "Bilgisayar görüşüne odaklanan, ilgili model eğitimi ve değerlendirmesini destekleyen açık veri setleri."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "BAAI开源数据集",
+    "name": {
+      "zh-CN": "BAAI开源数据集",
+      "en": "BAAI Open Datasets",
+      "tr": "BAAI Açık Veri Setleri"
+    },
     "link": "https://data.baai.ac.cn/data",
-    "description": "北京智源人工智能研究院提供的开源数据集，涵盖多个领域，支持大模型的训练。",
-    "labels": ["中文资源", "研究数据"]
+    "description": {
+      "zh-CN": "北京智源人工智能研究院提供的开源数据集，涵盖多个领域，支持大模型的训练。",
+      "en": "Open datasets from Beijing Academy of Artificial Intelligence, supporting large model training across multiple domains.",
+      "tr": "Pekin Yapay Zeka Akademisi'nden, birden fazla alanda büyük model eğitimini destekleyen açık veri setleri."
+    },
+    "labels": ["chinese_resource", "research"]
   },
   {
-    "name": "百度飞桨开源数据集",
+    "name": {
+      "zh-CN": "百度飞桨开源数据集",
+      "en": "Baidu PaddlePaddle Datasets",
+      "tr": "Baidu PaddlePaddle Veri Setleri"
+    },
     "link": "https://aistudio.baidu.com/datasetoverview",
-    "description": "百度飞桨平台提供的开源数据集，支持深度学习模型的训练和评估。",
-    "labels": ["中文资源"]
+    "description": {
+      "zh-CN": "百度飞桨平台提供的开源数据集，支持深度学习模型的训练和评估。",
+      "en": "Open datasets from Baidu's PaddlePaddle platform, supporting deep learning model training and evaluation.",
+      "tr": "Baidu'nun PaddlePaddle platformundan, derin öğrenme modeli eğitimi ve değerlendirmesini destekleyen açık veri setleri."
+    },
+    "labels": ["chinese_resource"]
   },
   {
-    "name": "启智开源数据集",
+    "name": {
+      "zh-CN": "启智开源数据集",
+      "en": "OpenI Open Datasets",
+      "tr": "OpenI Açık Veri Setleri"
+    },
     "link": "https://openi.pcl.ac.cn/explore/datasets",
-    "description": "开源平台提供的多种开源数据集，涵盖多个领域，支持模型的训练和研究。",
-    "labels": ["中文资源"]
+    "description": {
+      "zh-CN": "开源平台提供的多种开源数据集，涵盖多个领域，支持模型的训练和研究。",
+      "en": "Various open datasets from the OpenI platform, covering multiple domains, supporting model training and research.",
+      "tr": "OpenI platformundan, birden fazla alanı kapsayan, model eğitimi ve araştırmayı destekleyen çeşitli açık veri setleri."
+    },
+    "labels": ["chinese_resource"]
   },
   {
-    "name": "LAION-2B-en",
+    "name": {
+      "zh-CN": "LAION-2B-en",
+      "en": "LAION-2B-en",
+      "tr": "LAION-2B-en"
+    },
     "link": "https://laion.ai/",
-    "description": "包含25亿张图像和相应的文本描述，适用于多模态模型的训练。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "包含25亿张图像和相应的文本描述，适用于多模态模型的训练。",
+      "en": "Contains 2.5 billion images with corresponding text descriptions, suitable for multimodal model training.",
+      "tr": "2,5 milyar görüntü ve karşılık gelen metin açıklamalarını içerir, çok modlu model eğitimi için uygundur."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Common Crawl",
+    "name": {
+      "zh-CN": "Common Crawl",
+      "en": "Common Crawl",
+      "tr": "Common Crawl"
+    },
     "link": "https://commoncrawl.org/",
-    "description": "提供了大量的网页爬取数据，可用于语言模型的训练。",
-    "labels": ["英文资源", "研究数据"]
+    "description": {
+      "zh-CN": "提供了大量的网页爬取数据，可用于语言模型的训练。",
+      "en": "Provides large-scale web crawl data for language model training.",
+      "tr": "Dil modeli eğitimi için büyük ölçekli web tarama verileri sağlar."
+    },
+    "labels": ["english_resource", "research"]
   },
   {
-    "name": "The Pile",
+    "name": {
+      "zh-CN": "The Pile",
+      "en": "The Pile",
+      "tr": "The Pile"
+    },
     "link": "https://github.com/EleutherAI/the-pile",
-    "description": "由多个数据集组成的大型语言模型训练数据集，涵盖多种文本类型。",
-    "labels": ["研究数据", "英文资源"]
+    "description": {
+      "zh-CN": "由多个数据集组成的大型语言模型训练数据集，涵盖多种文本类型。",
+      "en": "A large language model training dataset composed of multiple datasets, covering various text types.",
+      "tr": "Çeşitli metin türlerini kapsayan, birden fazla veri setinden oluşan büyük bir dil modeli eğitim veri seti."
+    },
+    "labels": ["research", "english_resource"]
   },
   {
-    "name": "MuJoCo",
+    "name": {
+      "zh-CN": "MuJoCo",
+      "en": "MuJoCo",
+      "tr": "MuJoCo"
+    },
     "link": "https://mujoco.org/",
-    "description": "用于物理模拟的机器人交互数据集，适用于强化学习和机器人控制任务。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "用于物理模拟的机器人交互数据集，适用于强化学习和机器人控制任务。",
+      "en": "Robot interaction dataset for physics simulation, suitable for reinforcement learning and robot control tasks.",
+      "tr": "Fizik simülasyonu için robot etkileşim veri seti, pekiştirmeli öğrenme ve robot kontrol görevleri için uygundur."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Robotics Datasets",
+    "name": {
+      "zh-CN": "Robotics Datasets",
+      "en": "Robotics Datasets",
+      "tr": "Robotik Veri Setleri"
+    },
     "link": "https://roboticsdatasets.github.io/",
-    "description": "提供了多种机器人交互数据集，支持机器人学习和控制任务。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "提供了多种机器人交互数据集，支持机器人学习和控制任务。",
+      "en": "Provides various robot interaction datasets, supporting robot learning and control tasks.",
+      "tr": "Robot öğrenme ve kontrol görevlerini destekleyen çeşitli robot etkileşim veri setleri sunar."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Atari Games",
+    "name": {
+      "zh-CN": "Atari Games",
+      "en": "Atari Games",
+      "tr": "Atari Oyunları"
+    },
     "link": "https://www.atari.com/games",
-    "description": "经典的Atari游戏数据集，用于强化学习算法的基准测试。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "经典的Atari游戏数据集，用于强化学习算法的基准测试。",
+      "en": "Classic Atari game dataset for benchmarking reinforcement learning algorithms.",
+      "tr": "Pekiştirmeli öğrenme algoritmalarının kıyaslaması için klasik Atari oyun veri seti."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Web-crawled Interactions",
+    "name": {
+      "zh-CN": "Web-crawled Interactions",
+      "en": "Web-crawled Interactions",
+      "tr": "Web Tarama Etkileşimleri"
+    },
     "link": "https://commoncrawl.org/",
-    "description": "从网络平台上爬取的用户行为数据，适用于训练交互式代理。",
-    "labels": ["研究数据"]
+    "description": {
+      "zh-CN": "从网络平台上爬取的用户行为数据，适用于训练交互式代理。",
+      "en": "User behavior data crawled from web platforms, suitable for training interactive agents.",
+      "tr": "Web platformlarından toplanan kullanıcı davranış verileri, etkileşimli ajanların eğitimi için uygundur."
+    },
+    "labels": ["research"]
   },
   {
-    "name": "AI2 ARC Dataset",
+    "name": {
+      "zh-CN": "AI2 ARC Dataset",
+      "en": "AI2 ARC Dataset",
+      "tr": "AI2 ARC Veri Seti"
+    },
     "link": "https://allenai.org/data/arc",
-    "description": "用于评估AI常识推理和解决问题能力的多选题数据集。",
-    "labels": ["研究数据"]
+    "description": {
+      "zh-CN": "用于评估AI常识推理和解决问题能力的多选题数据集。",
+      "en": "Multiple-choice dataset for evaluating AI common sense reasoning and problem-solving abilities.",
+      "tr": "Yapay zekanın sağduyu muhakemesi ve problem çözme yeteneklerini değerlendirmek için çoktan seçmeli veri seti."
+    },
+    "labels": ["research"]
   },
   {
-    "name": "Speech Commands Dataset",
+    "name": {
+      "zh-CN": "Speech Commands Dataset",
+      "en": "Speech Commands Dataset",
+      "tr": "Konuşma Komutları Veri Seti"
+    },
     "link": "https://www.tensorflow.org/datasets/catalog/speech_commands",
-    "description": "包含数千个语音命令的音频数据集，适用于语音识别任务。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "包含数千个语音命令的音频数据集，适用于语音识别任务。",
+      "en": "Audio dataset containing thousands of voice commands, suitable for speech recognition tasks.",
+      "tr": "Binlerce sesli komut içeren ses veri seti, konuşma tanıma görevleri için uygundur."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Environmental Audio Datasets",
+    "name": {
+      "zh-CN": "Environmental Audio Datasets",
+      "en": "Environmental Audio Datasets",
+      "tr": "Çevresel Ses Veri Setleri"
+    },
     "link": "https://www.tensorflow.org/datasets/catalog/audioset",
-    "description": "包含环境声音事件的音频数据集，适用于音频场景分类任务。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "包含环境声音事件的音频数据集，适用于音频场景分类任务。",
+      "en": "Audio dataset containing environmental sound events, suitable for audio scene classification tasks.",
+      "tr": "Çevresel ses olaylarını içeren ses veri seti, ses sahne sınıflandırma görevleri için uygundur."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "COVID-19 Open Research Dataset",
+    "name": {
+      "zh-CN": "COVID-19 Open Research Dataset",
+      "en": "COVID-19 Open Research Dataset",
+      "tr": "COVID-19 Açık Araştırma Veri Seti"
+    },
     "link": "https://www.kaggle.com/allenai/cord-19-research-challenge",
-    "description": "包含45,000篇关于COVID-19的学术文章，适用于医疗AI研究。",
-    "labels": ["研究数据"]
+    "description": {
+      "zh-CN": "包含45,000篇关于COVID-19的学术文章，适用于医疗AI研究。",
+      "en": "Contains 45,000 scholarly articles about COVID-19, suitable for medical AI research.",
+      "tr": "COVID-19 hakkında 45.000 akademik makale içerir, tıbbi yapay zeka araştırmaları için uygundur."
+    },
+    "labels": ["research"]
   },
   {
-    "name": "Waymo Open Dataset",
+    "name": {
+      "zh-CN": "Waymo Open Dataset",
+      "en": "Waymo Open Dataset",
+      "tr": "Waymo Açık Veri Seti"
+    },
     "link": "https://waymo.com/open/",
-    "description": "由Waymo发布的最多样化的自动驾驶数据集。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "由Waymo发布的最多样化的自动驾驶数据集。",
+      "en": "The most diverse autonomous driving dataset released by Waymo.",
+      "tr": "Waymo tarafından yayınlanan en çeşitli otonom sürüş veri seti."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Labelme",
+    "name": {
+      "zh-CN": "Labelme",
+      "en": "Labelme",
+      "tr": "Labelme"
+    },
     "link": "http://labelme.csail.mit.edu/Release3.0/",
-    "description": "包含大量标注图像的数据集，适用于计算机视觉任务。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "包含大量标注图像的数据集，适用于计算机视觉任务。",
+      "en": "Dataset containing a large number of annotated images, suitable for computer vision tasks.",
+      "tr": "Çok sayıda etiketlenmiş görüntü içeren veri seti, bilgisayar görüşü görevleri için uygundur."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Stanford Dogs Dataset",
+    "name": {
+      "zh-CN": "Stanford Dogs Dataset",
+      "en": "Stanford Dogs Dataset",
+      "tr": "Stanford Köpekler Veri Seti"
+    },
     "link": "http://vision.stanford.edu/aditya86/ImageNetDogs/",
-    "description": "包含20,500多张不同狗品种的图像数据集。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "包含20,500多张不同狗品种的图像数据集。",
+      "en": "Image dataset containing over 20,500 images of different dog breeds.",
+      "tr": "Farklı köpek ırklarının 20.500'den fazla görüntüsünü içeren görüntü veri seti."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Flickr Audio Caption Corpus",
+    "name": {
+      "zh-CN": "Flickr Audio Caption Corpus",
+      "en": "Flickr Audio Caption Corpus",
+      "tr": "Flickr Sesli Altyazı Koleksiyonu"
+    },
     "link": "https://www.multispeech.org/2018/challenge.html",
-    "description": "包含超过40,000个口语描述的音频数据集。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "包含超过40,000个口语描述的音频数据集。",
+      "en": "Audio dataset containing over 40,000 spoken descriptions.",
+      "tr": "40.000'den fazla sözlü açıklama içeren ses veri seti."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Data.gov",
+    "name": {
+      "zh-CN": "Data.gov",
+      "en": "Data.gov",
+      "tr": "Data.gov"
+    },
     "link": "https://www.data.gov/",
-    "description": "美国政府开放数据平台，涵盖农业、气候、教育、能源等领域的公开数据集。",
-    "labels": ["政府数据", "英文资源"]
+    "description": {
+      "zh-CN": "美国政府开放数据平台，涵盖农业、气候、教育、能源等领域的公开数据集。",
+      "en": "U.S. government open data platform covering public datasets in agriculture, climate, education, energy, and more.",
+      "tr": "Tarım, iklim, eğitim, enerji ve daha fazla alanda açık veri setlerini kapsayan ABD hükümeti açık veri platformu."
+    },
+    "labels": ["government_data", "english_resource"]
   },
   {
-    "name": "Eurostat",
+    "name": {
+      "zh-CN": "Eurostat",
+      "en": "Eurostat",
+      "tr": "Eurostat"
+    },
     "link": "https://ec.europa.eu/eurostat",
-    "description": "欧盟统计局提供的经济、人口、社会等多领域统计数据。",
-    "labels": ["研究数据", "英文资源"]
+    "description": {
+      "zh-CN": "欧盟统计局提供的经济、人口、社会等多领域统计数据。",
+      "en": "Statistical data from the EU statistics office covering economics, population, society, and more.",
+      "tr": "AB istatistik ofisinden ekonomi, nüfus, toplum ve daha fazla alanı kapsayan istatistiksel veriler."
+    },
+    "labels": ["research", "english_resource"]
   },
   {
-    "name": "ImageNet",
+    "name": {
+      "zh-CN": "ImageNet",
+      "en": "ImageNet",
+      "tr": "ImageNet"
+    },
     "link": "https://www.image-net.org/",
-    "description": "大型图像数据集，包含数百万张标注图像，广泛用于计算机视觉任务。",
-    "labels": ["多模态", "计算机视觉"]
+    "description": {
+      "zh-CN": "大型图像数据集，包含数百万张标注图像，广泛用于计算机视觉任务。",
+      "en": "Large-scale image dataset containing millions of annotated images, widely used for computer vision tasks.",
+      "tr": "Milyonlarca etiketlenmiş görüntü içeren büyük ölçekli görüntü veri seti, bilgisayar görüşü görevlerinde yaygın olarak kullanılır."
+    },
+    "labels": ["multimodal", "computer_vision"]
   },
   {
-    "name": "COCO Dataset",
+    "name": {
+      "zh-CN": "COCO Dataset",
+      "en": "COCO Dataset",
+      "tr": "COCO Veri Seti"
+    },
     "link": "https://cocodataset.org/",
-    "description": "通用物体识别与分割数据集，适用于目标检测和图像分割任务。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "通用物体识别与分割数据集，适用于目标检测和图像分割任务。",
+      "en": "Common Objects in Context dataset for object detection and image segmentation tasks.",
+      "tr": "Nesne tespiti ve görüntü segmentasyonu görevleri için Bağlamda Ortak Nesneler veri seti."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "World Bank Open Data",
+    "name": {
+      "zh-CN": "World Bank Open Data",
+      "en": "World Bank Open Data",
+      "tr": "Dünya Bankası Açık Veri"
+    },
     "link": "https://data.worldbank.org/",
-    "description": "世界银行提供的全球经济指标、发展数据及统计报告。",
-    "labels": ["研究数据", "英文资源"]
+    "description": {
+      "zh-CN": "世界银行提供的全球经济指标、发展数据及统计报告。",
+      "en": "Global economic indicators, development data, and statistical reports from the World Bank.",
+      "tr": "Dünya Bankası'ndan küresel ekonomik göstergeler, kalkınma verileri ve istatistiksel raporlar."
+    },
+    "labels": ["research", "english_resource"]
   },
   {
-    "name": "NASA Earth Data",
+    "name": {
+      "zh-CN": "NASA Earth Data",
+      "en": "NASA Earth Data",
+      "tr": "NASA Dünya Verileri"
+    },
     "link": "https://earthdata.nasa.gov/",
-    "description": "NASA地球科学数据，涵盖气候、地质、环境等领域的遥感数据。",
-    "labels": ["研究数据", "地球科学"]
+    "description": {
+      "zh-CN": "NASA地球科学数据，涵盖气候、地质、环境等领域的遥感数据。",
+      "en": "NASA Earth science data covering climate, geology, and environmental remote sensing data.",
+      "tr": "İklim, jeoloji ve çevresel uzaktan algılama verilerini kapsayan NASA Dünya bilimi verileri."
+    },
+    "labels": ["research", "earth_science"]
   },
   {
-    "name": "Yelp Open Dataset",
+    "name": {
+      "zh-CN": "Yelp Open Dataset",
+      "en": "Yelp Open Dataset",
+      "tr": "Yelp Açık Veri Seti"
+    },
     "link": "https://www.yelp.com/dataset",
-    "description": "包含商家信息、用户评论和图片数据，适用于商业分析和NLP任务。",
-    "labels": ["商业", "英文资源"]
+    "description": {
+      "zh-CN": "包含商家信息、用户评论和图片数据，适用于商业分析和NLP任务。",
+      "en": "Contains business information, user reviews, and image data, suitable for business analytics and NLP tasks.",
+      "tr": "İşletme bilgileri, kullanıcı yorumları ve görüntü verileri içerir, iş analitiği ve NLP görevleri için uygundur."
+    },
+    "labels": ["business", "english_resource"]
   },
   {
-    "name": "CIFAR-10/100",
+    "name": {
+      "zh-CN": "CIFAR-10/100",
+      "en": "CIFAR-10/100",
+      "tr": "CIFAR-10/100"
+    },
     "link": "https://www.cs.toronto.edu/~kriz/cifar.html",
-    "description": "经典的小规模图像分类数据集，包含10或100个类别的标注图像。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "经典的小规模图像分类数据集，包含10或100个类别的标注图像。",
+      "en": "Classic small-scale image classification dataset containing annotated images in 10 or 100 categories.",
+      "tr": "10 veya 100 kategoride etiketlenmiş görüntüler içeren klasik küçük ölçekli görüntü sınıflandırma veri seti."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "Global Health Observatory (WHO)",
+    "name": {
+      "zh-CN": "Global Health Observatory (WHO)",
+      "en": "Global Health Observatory (WHO)",
+      "tr": "Küresel Sağlık Gözlemevi (WHO)"
+    },
     "link": "https://www.who.int/data/gho",
-    "description": "世界卫生组织提供的全球公共卫生统计数据，包括疾病、营养等主题。",
-    "labels": ["医疗健康", "研究数据"]
+    "description": {
+      "zh-CN": "世界卫生组织提供的全球公共卫生统计数据，包括疾病、营养等主题。",
+      "en": "Global public health statistics from WHO, covering topics such as diseases, nutrition, and more.",
+      "tr": "DSÖ'den hastalıklar, beslenme ve daha fazla konuyu kapsayan küresel halk sağlığı istatistikleri."
+    },
+    "labels": ["medical_health", "research"]
   },
   {
-    "name": "arXiv Dataset",
+    "name": {
+      "zh-CN": "arXiv Dataset",
+      "en": "arXiv Dataset",
+      "tr": "arXiv Veri Seti"
+    },
     "link": "https://www.kaggle.com/Cornell-University/arxiv",
-    "description": "包含数百万篇arXiv学术论文的元数据和全文，适用于文本挖掘研究。",
-    "labels": ["研究数据", "英文资源"]
+    "description": {
+      "zh-CN": "包含数百万篇arXiv学术论文的元数据和全文，适用于文本挖掘研究。",
+      "en": "Contains metadata and full text of millions of arXiv scholarly papers, suitable for text mining research.",
+      "tr": "Milyonlarca arXiv akademik makalenin meta verilerini ve tam metnini içerir, metin madenciliği araştırmaları için uygundur."
+    },
+    "labels": ["research", "english_resource"]
   },
   {
-    "name": "LibriSpeech",
+    "name": {
+      "zh-CN": "LibriSpeech",
+      "en": "LibriSpeech",
+      "tr": "LibriSpeech"
+    },
     "link": "https://www.openslr.org/12",
-    "description": "包含1000小时英语语音数据，适用于语音识别模型训练。",
-    "labels": ["多模态", "语音识别"]
+    "description": {
+      "zh-CN": "包含1000小时英语语音数据，适用于语音识别模型训练。",
+      "en": "Contains 1,000 hours of English speech data, suitable for speech recognition model training.",
+      "tr": "1.000 saat İngilizce konuşma verisi içerir, konuşma tanıma modeli eğitimi için uygundur."
+    },
+    "labels": ["multimodal", "speech_recognition"]
   },
   {
-    "name": "KITTI Vision Benchmark",
+    "name": {
+      "zh-CN": "KITTI Vision Benchmark",
+      "en": "KITTI Vision Benchmark",
+      "tr": "KITTI Görüş Kıyaslaması"
+    },
     "link": "http://www.cvlibs.net/datasets/kitti/",
-    "description": "自动驾驶领域经典数据集，包含立体视觉、激光雷达等多模态数据。",
-    "labels": ["多模态", "自动驾驶"]
+    "description": {
+      "zh-CN": "自动驾驶领域经典数据集，包含立体视觉、激光雷达等多模态数据。",
+      "en": "Classic autonomous driving dataset containing stereo vision, LiDAR, and other multimodal data.",
+      "tr": "Stereo görüş, LiDAR ve diğer çok modlu verileri içeren klasik otonom sürüş veri seti."
+    },
+    "labels": ["multimodal", "autonomous_driving"]
   },
   {
-    "name": "Cityscapes Dataset",
+    "name": {
+      "zh-CN": "Cityscapes Dataset",
+      "en": "Cityscapes Dataset",
+      "tr": "Cityscapes Veri Seti"
+    },
     "link": "https://www.cityscapes-dataset.com/",
-    "description": "城市街景语义分割数据集，支持自动驾驶和计算机视觉研究。",
-    "labels": ["多模态"]
+    "description": {
+      "zh-CN": "城市街景语义分割数据集，支持自动驾驶和计算机视觉研究。",
+      "en": "Urban street scene semantic segmentation dataset, supporting autonomous driving and computer vision research.",
+      "tr": "Otonom sürüş ve bilgisayar görüşü araştırmalarını destekleyen kentsel sokak sahnesi anlamsal segmentasyon veri seti."
+    },
+    "labels": ["multimodal"]
   },
   {
-    "name": "CDC Data",
+    "name": {
+      "zh-CN": "CDC Data",
+      "en": "CDC Data",
+      "tr": "CDC Verileri"
+    },
     "link": "https://data.cdc.gov/",
-    "description": "美国疾病控制与预防中心发布的公共卫生数据集，涵盖疾病追踪和健康统计。",
-    "labels": ["医疗健康", "政府数据"]
+    "description": {
+      "zh-CN": "美国疾病控制与预防中心发布的公共卫生数据集，涵盖疾病追踪和健康统计。",
+      "en": "Public health datasets from the U.S. CDC, covering disease tracking and health statistics.",
+      "tr": "ABD CDC'den hastalık takibi ve sağlık istatistiklerini kapsayan halk sağlığı veri setleri."
+    },
+    "labels": ["medical_health", "government_data"]
   },
   {
-    "name": "OpenStreetMap",
+    "name": {
+      "zh-CN": "OpenStreetMap",
+      "en": "OpenStreetMap",
+      "tr": "OpenStreetMap"
+    },
     "link": "https://www.openstreetmap.org/",
-    "description": "开源地理数据协作项目，提供全球范围的道路、建筑等地理信息数据。",
-    "labels": ["地理信息", "众包数据"]
+    "description": {
+      "zh-CN": "开源地理数据协作项目，提供全球范围的道路、建筑等地理信息数据。",
+      "en": "Open-source geographic data collaboration project providing worldwide road, building, and other geographic information.",
+      "tr": "Dünya çapında yol, bina ve diğer coğrafi bilgileri sağlayan açık kaynak coğrafi veri işbirliği projesi."
+    },
+    "labels": ["geographic_info", "crowdsourced"]
   },
   {
-    "name": "FiveThirtyEight Datasets",
+    "name": {
+      "zh-CN": "FiveThirtyEight Datasets",
+      "en": "FiveThirtyEight Datasets",
+      "tr": "FiveThirtyEight Veri Setleri"
+    },
     "link": "https://data.fivethirtyeight.com/",
-    "description": "涵盖政治、体育、文化等领域的数据集，常用于数据新闻分析。",
-    "labels": ["社会趋势", "英文资源"]
+    "description": {
+      "zh-CN": "涵盖政治、体育、文化等领域的数据集，常用于数据新闻分析。",
+      "en": "Datasets covering politics, sports, culture, and more, commonly used for data journalism analysis.",
+      "tr": "Siyaset, spor, kültür ve daha fazla alanı kapsayan, veri gazeteciliği analizi için yaygın olarak kullanılan veri setleri."
+    },
+    "labels": ["social_trends", "english_resource"]
   },
   {
-    "name": "Human Protein Atlas",
+    "name": {
+      "zh-CN": "Human Protein Atlas",
+      "en": "Human Protein Atlas",
+      "tr": "İnsan Protein Atlası"
+    },
     "link": "https://www.proteinatlas.org/",
-    "description": "包含人体蛋白质分布的组织图像数据，支持生物医学研究。",
-    "labels": ["医疗健康", "研究数据"]
+    "description": {
+      "zh-CN": "包含人体蛋白质分布的组织图像数据，支持生物医学研究。",
+      "en": "Contains tissue image data on human protein distribution, supporting biomedical research.",
+      "tr": "İnsan protein dağılımı üzerine doku görüntü verileri içerir, biyomedikal araştırmaları destekler."
+    },
+    "labels": ["medical_health", "research"]
   }
 ]

--- a/lib/util/sites-i18n.js
+++ b/lib/util/sites-i18n.js
@@ -1,0 +1,14 @@
+/**
+ * Get a localized field from a site object.
+ * Supports both new format (object with locale keys) and legacy format (plain string).
+ * @param {Object} site - The site object from sites.json
+ * @param {string} field - The field name (e.g. 'name', 'description')
+ * @param {string} language - The current language code (e.g. 'en', 'zh-CN', 'tr')
+ * @returns {string} The localized value
+ */
+export function getSiteField(site, field, language) {
+  const value = site[field];
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  return value[language] || value['en'] || value['zh-CN'] || '';
+}

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -952,7 +952,24 @@
     "noDatasets": "No datasets found matching your criteria",
     "tryOtherCategories": "Please try other categories or return to view all datasets",
     "dataset": "Dataset",
-    "viewDataset": "View Dataset"
+    "viewDataset": "View Dataset",
+    "labels": {
+      "popular": "Popular",
+      "chinese_resource": "Chinese Resources",
+      "english_resource": "English Resources",
+      "research": "Research Data",
+      "multimodal": "Multimodal",
+      "computer_vision": "Computer Vision",
+      "autonomous_driving": "Autonomous Driving",
+      "medical_health": "Medical Health",
+      "government_data": "Government Data",
+      "earth_science": "Earth Science",
+      "business": "Business",
+      "social_trends": "Social Trends",
+      "geographic_info": "Geographic Info",
+      "crowdsourced": "Crowdsourced",
+      "speech_recognition": "Speech Recognition"
+    }
   },
   "playground": {
     "title": "Model Testing",

--- a/locales/tr/translation.json
+++ b/locales/tr/translation.json
@@ -931,7 +931,24 @@
     "noDatasets": "Kriterlerinize uygun veri seti bulunamadı",
     "tryOtherCategories": "Lütfen diğer kategorileri deneyin veya tüm veri setlerini görüntülemek için geri dönün",
     "dataset": "Veri Seti",
-    "viewDataset": "Veri Setini Görüntüle"
+    "viewDataset": "Veri Setini Görüntüle",
+    "labels": {
+      "popular": "Popüler",
+      "chinese_resource": "Çince Kaynaklar",
+      "english_resource": "İngilizce Kaynaklar",
+      "research": "Araştırma Verileri",
+      "multimodal": "Çok Modlu",
+      "computer_vision": "Bilgisayar Görüşü",
+      "autonomous_driving": "Otonom Sürüş",
+      "medical_health": "Tıbbi Sağlık",
+      "government_data": "Devlet Verileri",
+      "earth_science": "Yer Bilimleri",
+      "business": "İş",
+      "social_trends": "Sosyal Eğilimler",
+      "geographic_info": "Coğrafi Bilgi",
+      "crowdsourced": "Kitle Kaynaklı",
+      "speech_recognition": "Konuşma Tanıma"
+    }
   },
   "playground": {
     "title": "Model Testi",

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -939,7 +939,24 @@
     "noDatasets": "没有找到符合条件的数据集",
     "tryOtherCategories": "请尝试其他分类或返回全部数据集查看",
     "dataset": "数据集",
-    "viewDataset": "查看数据集"
+    "viewDataset": "查看数据集",
+    "labels": {
+      "popular": "热门推荐",
+      "chinese_resource": "中文资源",
+      "english_resource": "英文资源",
+      "research": "研究数据",
+      "multimodal": "多模态",
+      "computer_vision": "计算机视觉",
+      "autonomous_driving": "自动驾驶",
+      "medical_health": "医疗健康",
+      "government_data": "政府数据",
+      "earth_science": "地球科学",
+      "business": "商业",
+      "social_trends": "社会趋势",
+      "geographic_info": "地理信息",
+      "crowdsourced": "众包数据",
+      "speech_recognition": "语音识别"
+    }
   },
   "playground": {
     "title": "模型测试",


### PR DESCRIPTION
## Problem

Fixes #702

The Dataset Square page (`constant/sites.json`) has all content hardcoded in Chinese:
- **Labels** (e.g. `热门推荐`, `多模态`) are compared against `t()` translated strings for filtering
- Since `t('datasetSquare.categories.popular')` returns `'Popular'` in English but the JSON has `'热门推荐'`, **filtering only works when the UI is in Chinese**
- **Names** and **descriptions** are also Chinese-only, affecting non-Chinese users

## Solution

### 1. Locale-neutral label keys in `sites.json`
Changed labels from Chinese strings to locale-neutral English keys:
- `热门推荐` → `popular`
- `中文资源` → `chinese_resource`
- `英文资源` → `english_resource`
- `研究数据` → `research`
- `多模态` → `multimodal`
- Plus 10 additional label keys for specialized categories

### 2. Locale-keyed name/description objects
Changed flat Chinese strings to locale-keyed objects:
```json
{
  "name": { "zh-CN": "HuggingFace开源数据集", "en": "HuggingFace Open Datasets" },
  "description": { "zh-CN": "...", "en": "..." },
  "labels": ["popular", "multimodal"]
}
```

### 3. Helper utility: `getSiteField()`
Created `lib/util/sites-i18n.js` with a helper that reads the right locale from the object, falling back to `en` → `zh-CN`:
```js
getSiteField(site, 'name', i18n.language)
```

### 4. Simplified filtering logic
**Before** (broken for non-Chinese):
```js
sites.filter(site => site.labels.includes(t('datasetSquare.categories.popular')))
```
**After** (language-independent):
```js
sites.filter(site => site.labels.includes(activeCategory))  // activeCategory = 'popular'
```

### 5. Translation keys for label display
Added `datasetSquare.labels.*` translation keys in all 4 locales (zh-CN, en, tr, pt-BR) so label Chips render correctly in every language.

## Files Changed
| File | Change |
|------|--------|
| `constant/sites.json` | Labels → keys, name/desc → locale objects |
| `components/dataset-square/DatasetSiteList.js` | Key-based filtering, translated tab labels |
| `components/dataset-square/DatasetSiteCard.js` | Localized name/desc/labels via helper |
| `components/dataset-square/DatasetSearchBar.js` | Localized site name in suggestions |
| `lib/util/sites-i18n.js` | New helper utility |
| `locales/{zh-CN,en,tr,pt-BR}/translation.json` | Added `datasetSquare.labels.*` keys |

## Adding more languages
To add a new language, just:
1. Add the locale key to name/description objects in `sites.json` (optional — falls back to `en`)
2. Add `datasetSquare.labels.*` translations in the new locale file
