### PR TITLE
fix(i18n): add 30 missing keys to English translation

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -252,6 +252,9 @@
     "generateMultiTurnDataset": "Generate Multi-Turn Dataset",
     "generateImageDataset": "Generate Image Q&A Dataset",
     "generateMultiTurnDatasetDesc": "Generate multi-turn conversation dataset based on questions",
+    "multiTurnNotConfigured": "Please configure multi-turn conversation parameters in project settings first",
+    "generateMultiTurn": "Generate Multi-Turn Conversation",
+    "multiTurnGenerated": "Multi-turn conversation dataset generated successfully!",
     "deleteConfirm": "Are you sure you want to delete this question? This action cannot be undone."
   },
   "common": {
@@ -350,7 +353,9 @@
     "deleteSuccess": "Project deleted successfully",
     "deleteFailed": "Failed to delete project",
     "backToHome": "Back to Home",
-    "deleteConfirmTitle": "Confirm Delete"
+    "deleteConfirmTitle": "Confirm Delete",
+    "title": "Project Management",
+    "openDirectory": "Open Project Directory"
   },
   "textSplit": {
     "dragToUpload": "Drag files to upload",
@@ -596,7 +601,32 @@
     "sampleAnalysis": "Model's chain of thought content",
     "sampleFinal": "Model response",
     "sampleThinking": "Model's chain of thought content",
-    "fetchLabelStatsError": "Failed to fetch label statistics:"
+    "fetchLabelStatsError": "Failed to fetch label statistics:",
+    "answerFieldName": "Answer Field Name",
+    "cotFieldName": "CoT Field Name",
+    "includeLabels": "Include Labels",
+    "includeChunk": "Include Text Chunk",
+    "questionOnly": "Export Questions Only",
+    "localTab": "Local Export",
+    "llamaFactoryTab": "Use in LLaMA Factory",
+    "huggingFaceTab": "Upload to HuggingFace",
+    "configExists": "Configuration File Exists",
+    "configPath": "Configuration File Path",
+    "updateConfig": "Update LLaMA Factory Configuration",
+    "noConfig": "No configuration file exists, click the button below to generate",
+    "generateConfig": "Generate LLaMA Factory Configuration",
+    "huggingFaceComingSoon": "HuggingFace export feature coming soon",
+    "uploadToHuggingFace": "Upload to HuggingFace",
+    "datasetName": "Dataset Name",
+    "datasetNameHelp": "Format: username/dataset-name",
+    "privateDataset": "Private Dataset",
+    "datasetSettings": "Dataset Settings",
+    "exportOptions": "Export Options",
+    "uploadSuccess": "Dataset uploaded successfully to HuggingFace",
+    "viewOnHuggingFace": "View on HuggingFace",
+    "noTokenWarning": "Hugging Face Token not found. Please configure it in project settings.",
+    "goToSettings": "Go to Settings",
+    "tokenHelp": "You can get your token from HuggingFace settings page"
   },
   "import": {
     "title": "Import",


### PR DESCRIPTION
## Summary

Adds 30 missing translation keys to the English locale that exist in ZH-CN and are actively used by the code.

## Problem

1. **25 \export.*\ keys** exist in \zh-CN\ and are used by components (\ExportDatasetDialog.js\, \LocalExportTab.js\), but were only present under \export_extended.*\ in EN — a namespace **never referenced by any component**. This means these strings always fell back to defaults.

2. **3 \questions.*\ keys** (\multiTurnNotConfigured\, \generateMultiTurn\, \multiTurnGenerated\) are used in \QuestionListView.js\ but missing from EN.

3. **2 \projects.*\ keys** (\	itle\, \openDirectory\) — \openDirectory\ is used in \ProjectCard.js\.

## Changes

- \locales/en/translation.json\: +32 lines, adds all 30 missing keys under correct namespaces

## Verification

After this change: **ZH not EN = 0** (all ZH-CN keys are now covered in EN)

## Note

The \export_extended.*\ keys remain untouched for backward compatibility but are effectively dead code.