### PR TITLE
fix: ReferenceError - controller not defined in useMultiTurnData.js

### DIFF
--- a/app/projects/[projectId]/multi-turn/hooks/useMultiTurnData.js
+++ b/app/projects/[projectId]/multi-turn/hooks/useMultiTurnData.js
@@ -59,11 +59,11 @@ export const useMultiTurnData = projectId => {
     const filterValues = options.filterValues ?? filters;
     const showLoading = options.showLoading ?? true;
 
+    const controller = new AbortController();
     try {
       if (abortRef.current) {
         abortRef.current.abort();
       }
-      const controller = new AbortController();
       abortRef.current = controller;
 
       if (showLoading) {


### PR DESCRIPTION
## Summary

Fixes #706

## Problem

`ReferenceError: controller is not defined` occurs when navigating to the multi-turn conversation dataset page.

The `controller` variable was declared with `const` inside the `try` block but referenced in the `finally` block, which is outside the `try` scope.

## Fix

Moved `const controller = new AbortController()` before the `try` block so it is accessible in both `try` and `finally`.

## Changes

- `app/projects/[projectId]/multi-turn/hooks/useMultiTurnData.js`: Moved AbortController instantiation before try block (1 line moved)