### PR TITLE
fix(i18n): add missing ContextBar translation keys for EN and ZH-CN

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -314,7 +314,10 @@
     "back": "Back",
     "refresh": "Refresh",
     "expand": "Expand All",
-    "collapse": "Collapse"
+    "collapse": "Collapse",
+    "project": "Project",
+    "error": "Error",
+    "contextNavigation": "Context navigation"
   },
   "home": {
     "title": "Easy Dataset",
@@ -326,6 +329,8 @@
     "reuseConfig": "Reuse Model Config",
     "noReuse": "No Configuration Reuse",
     "selectProject": "Select Project",
+    "allProjects": "All Projects",
+    "projectMenu": "Project menu",
     "fetchFailed": "Failed to fetch project list",
     "fetchError": "Error fetching project list",
     "loading": "Loading your projects...",

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -315,7 +315,10 @@
     "back": "返回",
     "refresh": "刷新",
     "expand": "展开全部",
-    "collapse": "收起内容"
+    "collapse": "收起内容",
+    "project": "项目",
+    "error": "错误",
+    "contextNavigation": "上下文导航"
   },
   "home": {
     "title": "Easy Dataset",
@@ -327,6 +330,8 @@
     "reuseConfig": "复用模型配置",
     "noReuse": "不复用配置",
     "selectProject": "选择项目",
+    "allProjects": "所有项目",
+    "projectMenu": "项目菜单",
     "fetchFailed": "获取项目列表失败",
     "fetchError": "获取项目列表出错",
     "loading": "正在加载您的项目...",


### PR DESCRIPTION
## Summary

Fixes #708

## Problem

The ContextBar component (project selector in the navigation bar) uses 5 i18n keys that are not defined in the English or Chinese translation files. This causes hardcoded English fallback strings to always be displayed regardless of the active language.

For example, Chinese users see \PROJECT:\ and \ALL PROJECTS\ in English instead of \项目:\ and \所有项目\.

## Changes

Added the following keys to both \locales/en/translation.json\ and \locales/zh-CN/translation.json\:

| Key | EN | ZH-CN |
|-----|-----|-------|
| \common.project\ | Project | 项目 |
| \common.error\ | Error | 错误 |
| \common.contextNavigation\ | Context navigation | 上下文导航 |
| \projects.allProjects\ | All Projects | 所有项目 |
| \projects.projectMenu\ | Project menu | 项目菜单 |

## Files Changed

- \locales/en/translation.json\ — 5 keys added
- \locales/zh-CN/translation.json\ — 5 keys added