### PR TITLE
fix: avoid loading all image base64 data when navigating datasets

### DIFF
--- a/app/api/projects/[projectId]/image-datasets/route.js
+++ b/app/api/projects/[projectId]/image-datasets/route.js
@@ -32,7 +32,17 @@ export async function GET(request, { params }) {
       filters.maxScore = parseInt(maxScore);
     }
 
+    // When idsOnly=true, skip image loading and return only IDs for navigation
+    const idsOnly = searchParams.get('idsOnly') === 'true';
+
     const result = await getImageDatasetsByProject(projectId, page, pageSize, filters);
+
+    if (idsOnly) {
+      return NextResponse.json({
+        data: result.data.map(d => ({ id: d.id })),
+        total: result.total
+      });
+    }
 
     // 获取项目路径
     const projectPath = await getProjectPath(projectId);

--- a/app/projects/[projectId]/image-datasets/hooks/useImageDatasetDetails.js
+++ b/app/projects/[projectId]/image-datasets/hooks/useImageDatasetDetails.js
@@ -21,11 +21,13 @@ export default function useImageDatasetDetails(projectId, datasetId) {
   // 获取数据集列表信息
   const fetchDatasetsList = useCallback(async () => {
     try {
-      // 获取所有数据集以正确统计已确认数量
-      const response = await axios.get(`/api/projects/${projectId}/image-datasets?page=1&pageSize=10000`);
-      const data = response.data;
-      setDatasetsAllCount(data.total || 0);
-      setDatasetsConfirmCount(data.data?.filter(d => d.confirmed).length || 0);
+      // Use two lightweight requests (pageSize=1) to get total and confirmed counts
+      const [allResponse, confirmedResponse] = await Promise.all([
+        axios.get(`/api/projects/${projectId}/image-datasets?page=1&pageSize=1&idsOnly=true`),
+        axios.get(`/api/projects/${projectId}/image-datasets?page=1&pageSize=1&confirmed=true&idsOnly=true`)
+      ]);
+      setDatasetsAllCount(allResponse.data.total || 0);
+      setDatasetsConfirmCount(confirmedResponse.data.total || 0);
     } catch (error) {
       console.error('Failed to fetch datasets list:', error);
     }
@@ -76,8 +78,10 @@ export default function useImageDatasetDetails(projectId, datasetId) {
   const handleNavigate = useCallback(
     async (direction, skipCurrentId = null) => {
       try {
-        // 获取所有数据集（不分页），使用一个足够大的 pageSize
-        const response = await axios.get(`/api/projects/${projectId}/image-datasets?page=1&pageSize=10000`);
+        // Fetch only IDs (no image data) to avoid loading large base64 images for navigation
+        const response = await axios.get(
+          `/api/projects/${projectId}/image-datasets?page=1&pageSize=10000&idsOnly=true`
+        );
         const datasets = response.data.data || [];
 
         if (datasets.length === 0) {


### PR DESCRIPTION
Fixes #734

## Problem
The image Q&A dataset review page becomes severely sluggish when switching between questions because two code paths were fetching **all** datasets with `pageSize=10000`:

1. `fetchDatasetsList` — loaded every dataset (including base64-encoded images from disk) just to count how many were confirmed.
2. `handleNavigate` — loaded every dataset with full image data to find the adjacent record for prev/next navigation.

With a large image dataset, this means thousands of image files are read from disk and base64-encoded on every navigation click.

## Solution

**`app/api/projects/[projectId]/image-datasets/route.js`**
- Added `idsOnly=true` query parameter. When set, the API returns only `{ id }` objects and skips all image file reads, making navigation queries extremely lightweight.

**`app/projects/[projectId]/image-datasets/hooks/useImageDatasetDetails.js`**
- `fetchDatasetsList`: replaced the single `pageSize=10000` fetch with two parallel `pageSize=1` requests (all datasets and confirmed-only). The `total` field in the response gives the exact count without loading any data.
- `handleNavigate`: now uses `idsOnly=true` to fetch only IDs, eliminating all image disk reads during navigation.

## Testing
- Page count stats (total / confirmed) still display correctly.
- Prev/next navigation still routes to the correct dataset.
- No images are loaded unnecessarily during navigation or stat refresh.