### PR TITLE
fix: enable GFM tables in ReactMarkdown previews

### DIFF
--- a/app/projects/[projectId]/blind-test-tasks/components/BlindTestInProgress.js
+++ b/app/projects/[projectId]/blind-test-tasks/components/BlindTestInProgress.js
@@ -28,6 +28,7 @@ import AssignmentIcon from '@mui/icons-material/Assignment';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import 'github-markdown-css/github-markdown-light.css';
 import { blindTestStyles } from '@/styles/blindTest';
 
@@ -162,7 +163,7 @@ function AnswerBox({ title, modelLabel, answer, streaming, showThinking, setShow
 
           {answer?.content ? (
             <div className="markdown-body" style={{ fontSize: '0.95rem', backgroundColor: 'transparent' }}>
-              <ReactMarkdown>{answer.content}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer.content}</ReactMarkdown>
             </div>
           ) : streaming ? (
             <Box

--- a/app/projects/[projectId]/blind-test-tasks/components/ResultDetailList.js
+++ b/app/projects/[projectId]/blind-test-tasks/components/ResultDetailList.js
@@ -1,5 +1,6 @@
 import { Box, Paper, Typography, Chip, Collapse, IconButton, Avatar, Divider, Grid } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next';
 import { useTheme, alpha } from '@mui/material/styles';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -137,7 +138,7 @@ function ResultAnswerSection({ title, rawContent, isWinner, modelLabel, t, theme
 
         {/* 正文内容 */}
         <div className="markdown-body" style={{ fontSize: '0.95rem', backgroundColor: 'transparent' }}>
-          <ReactMarkdown>{content || '-'}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content || '-'}</ReactMarkdown>
         </div>
       </Paper>
     </Box>

--- a/app/projects/[projectId]/eval-tasks/[taskId]/components/QuestionCard.js
+++ b/app/projects/[projectId]/eval-tasks/[taskId]/components/QuestionCard.js
@@ -9,6 +9,7 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { detailStyles } from '../detailStyles';
 import { useTranslation } from 'react-i18next';
 import 'github-markdown-css/github-markdown-light.css';
@@ -221,7 +222,7 @@ export default function QuestionCard({ result, index, task }) {
         <Box ref={contentRef} sx={detailStyles.markdownContainer(isExpanded)}>
           {questionType === 'open_ended' || questionType === 'short_answer' ? (
             <div className="markdown-body">
-              <ReactMarkdown>{modelAnswer || ''}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{modelAnswer || ''}</ReactMarkdown>
             </div>
           ) : (
             <Typography
@@ -272,7 +273,7 @@ export default function QuestionCard({ result, index, task }) {
           <Box ref={correctContentRef} sx={detailStyles.markdownContainer(isCorrectExpanded)}>
             {questionType === 'open_ended' || questionType === 'short_answer' ? (
               <div className="markdown-body">
-                <ReactMarkdown>{correctAnswer || ''}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{correctAnswer || ''}</ReactMarkdown>
               </div>
             ) : (
               <Typography

--- a/app/projects/[projectId]/settings/components/PromptDetail.js
+++ b/app/projects/[projectId]/settings/components/PromptDetail.js
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Card, CardContent, Box, Typography, Chip, Button, Paper } from '@mui/material';
 import { Edit as EditIcon, Restore as RestoreIcon } from '@mui/icons-material';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 import 'github-markdown-css/github-markdown-light.css';
 
@@ -81,7 +82,7 @@ const PromptDetail = ({
           }}
         >
           <div className="markdown-body">
-            <ReactMarkdown>{promptContent}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{promptContent}</ReactMarkdown>
           </div>
         </Paper>
       </CardContent>

--- a/components/datasets/EditableField.js
+++ b/components/datasets/EditableField.js
@@ -15,6 +15,7 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import 'github-markdown-css/github-markdown-light.css';
@@ -72,7 +73,7 @@ function getValue(value, answerType, useMarkdown, t, onOptimize) {
     }
     return useMarkdown ? (
       <div className="markdown-body">
-        <ReactMarkdown>{value}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
       </div>
     ) : (
       <Typography variant="body1">{value}</Typography>

--- a/components/text-split/ChunkViewDialog.js
+++ b/components/text-split/ChunkViewDialog.js
@@ -2,6 +2,7 @@
 
 import { Box, Button, Dialog, DialogTitle, DialogContent, DialogActions, CircularProgress } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next';
 import 'github-markdown-css/github-markdown-light.css';
 
@@ -14,7 +15,7 @@ export default function ChunkViewDialog({ open, chunk, onClose }) {
         {chunk ? (
           <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
             <div className="markdown-body">
-              <ReactMarkdown>{chunk.content}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{chunk.content}</ReactMarkdown>
             </div>
           </Box>
         ) : (

--- a/components/text-split/DomainAnalysis.js
+++ b/components/text-split/DomainAnalysis.js
@@ -29,6 +29,7 @@ import {
 import { useTheme } from '@mui/material/styles';
 import TabPanel from './components/TabPanel';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import AddIcon from '@mui/icons-material/Add';
@@ -480,6 +481,7 @@ export default function DomainAnalysis({ projectId, toc = '', loading = false })
               >
                 <div className="markdown-body">
                   <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
                     components={{
                       root: ({ children }) => (
                         <div

--- a/components/text-split/MarkdownViewDialog.js
+++ b/components/text-split/MarkdownViewDialog.js
@@ -20,6 +20,7 @@ import {
 import DeleteIcon from '@mui/icons-material/Delete';
 import SaveIcon from '@mui/icons-material/Save';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next';
 import 'github-markdown-css/github-markdown-light.css';
 
@@ -392,7 +393,7 @@ export default function MarkdownViewDialog({ open, text, onClose, projectId, onS
             ) : (
               <Box>
                 <div className="markdown-body">
-                  <ReactMarkdown>{text.content}</ReactMarkdown>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{text.content}</ReactMarkdown>
                 </div>
               </Box>
             )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react-i18next": "^15.4.1",
         "react-markdown": "^10.0.1",
         "recharts": "^3.6.0",
+        "remark-gfm": "^4.0.1",
         "sharp": "^0.33.1",
         "sonner": "^2.0.3",
         "turndown": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-i18next": "^15.4.1",
     "react-markdown": "^10.0.1",
     "recharts": "^3.6.0",
+    "remark-gfm": "^4.0.1",
     "sharp": "^0.33.1",
     "sonner": "^2.0.3",
     "turndown": "^7.2.0",


### PR DESCRIPTION
## Summary

Markdown tables, strikethrough, and task lists were rendered as raw pipe text (`|...|`) in all preview surfaces because `react-markdown` only supports CommonMark by default. This PR adds the `remark-gfm` plugin to every `ReactMarkdown` usage so GitHub Flavored Markdown renders correctly.

## Problem

`react-markdown@10` ships with CommonMark only. Without `remark-gfm`, GFM-specific syntax — tables, strikethrough, task lists, autolinks — falls through as plain text. This is most visible in the dataset answer preview where model-generated tables become a wall of `|` characters.

The package `remark-gfm` was already present in `node_modules` as a transitive dependency of `react-markdown` but was not explicitly declared in `package.json` and was not passed to any `ReactMarkdown` component.

## Fix

- Added `import remarkGfm from 'remark-gfm'` and `remarkPlugins={[remarkGfm]}` to every `ReactMarkdown` usage.
- Declared `remark-gfm: ^4.0.1` in `package.json` dependencies so it is no longer a hidden transitive.

## Changes

| File | Surface |
|------|---------|
| `components/datasets/EditableField.js` | Dataset question/answer preview |
| `app/projects/[projectId]/eval-tasks/[taskId]/components/QuestionCard.js` | Eval task model answer & correct answer |
| `app/projects/[projectId]/blind-test-tasks/components/BlindTestInProgress.js` | Blind test in-progress answer stream |
| `app/projects/[projectId]/blind-test-tasks/components/ResultDetailList.js` | Blind test result detail |
| `app/projects/[projectId]/settings/components/PromptDetail.js` | Prompt preview |
| `components/text-split/MarkdownViewDialog.js` | Markdown view dialog |
| `components/text-split/ChunkViewDialog.js` | Chunk preview dialog |
| `components/text-split/DomainAnalysis.js` | Domain analysis TOC |
| `package.json` | Added `remark-gfm` as explicit dependency |

## Verification

Toggle Markdown mode on a dataset answer containing a GFM table — the table now renders as a styled HTML table instead of raw pipe text.