### PR TITLE
fix: retain active list filters when navigating between datasets

### DIFF
--- a/app/api/projects/[projectId]/datasets/[datasetId]/route.js
+++ b/app/api/projects/[projectId]/datasets/[datasetId]/route.js
@@ -17,7 +17,22 @@ export async function GET(request, { params }) {
     const { searchParams } = new URL(request.url);
     const operateType = searchParams.get('operateType');
     if (operateType !== null) {
-      const data = await getNavigationItems(projectId, datasetId, operateType);
+      const status = searchParams.get('status');
+      let confirmed = undefined;
+      if (status === 'confirmed') confirmed = true;
+      if (status === 'unconfirmed') confirmed = false;
+      const filters = {
+        confirmed,
+        input: searchParams.get('input') || '',
+        field: searchParams.get('field') || 'question',
+        hasCot: searchParams.get('hasCot') || 'all',
+        isDistill: searchParams.get('isDistill') || 'all',
+        scoreRange: searchParams.get('scoreRange') || '',
+        customTag: searchParams.get('customTag') || '',
+        noteKeyword: searchParams.get('noteKeyword') || '',
+        chunkName: searchParams.get('chunkName') || ''
+      };
+      const data = await getNavigationItems(projectId, datasetId, operateType, filters);
       return NextResponse.json(data);
     }
     const datasets = await getDatasetsById(datasetId);

--- a/app/projects/[projectId]/datasets/[datasetId]/useDatasetDetails.js
+++ b/app/projects/[projectId]/datasets/[datasetId]/useDatasetDetails.js
@@ -180,7 +180,45 @@ export default function useDatasetDetails(projectId, datasetId) {
 
   // 导航到其他数据集
   const handleNavigate = async direction => {
-    const response = await axios.get(`/api/projects/${projectId}/datasets/${datasetId}?operateType=${direction}`);
+    const params = new URLSearchParams({ operateType: direction });
+
+    // Apply active list filters so navigation stays within the filtered set
+    try {
+      const savedFilters = localStorage.getItem(`datasets-filters-${projectId}`);
+      if (savedFilters) {
+        const {
+          filterConfirmed,
+          filterChunkName,
+          filterHasCot,
+          filterIsDistill,
+          filterScoreRange,
+          filterCustomTag,
+          filterNoteKeyword,
+          searchQuery,
+          searchField
+        } = JSON.parse(savedFilters);
+
+        if (filterConfirmed === 'confirmed') params.set('status', 'confirmed');
+        else if (filterConfirmed === 'unconfirmed') params.set('status', 'unconfirmed');
+
+        if (filterChunkName) params.set('chunkName', filterChunkName);
+        if (filterHasCot && filterHasCot !== 'all') params.set('hasCot', filterHasCot);
+        if (filterIsDistill && filterIsDistill !== 'all') params.set('isDistill', filterIsDistill);
+        if (filterScoreRange && (filterScoreRange[0] > 0 || filterScoreRange[1] < 5)) {
+          params.set('scoreRange', `${filterScoreRange[0]}-${filterScoreRange[1]}`);
+        }
+        if (filterCustomTag) params.set('customTag', filterCustomTag);
+        if (filterNoteKeyword) params.set('noteKeyword', filterNoteKeyword);
+        if (searchQuery) {
+          params.set('input', searchQuery);
+          params.set('field', searchField || 'question');
+        }
+      }
+    } catch (e) {
+      console.error('Failed to read filter conditions for navigation:', e);
+    }
+
+    const response = await axios.get(`/api/projects/${projectId}/datasets/${datasetId}?${params}`);
     if (response.data) {
       router.push(`/projects/${projectId}/datasets/${response.data.id}`);
     } else {

--- a/lib/db/datasets.js
+++ b/lib/db/datasets.js
@@ -515,21 +515,80 @@ export async function getDatasetsCounts(projectId) {
   }
 }
 
-export async function getNavigationItems(projectId, datasetId, operateType) {
+export async function getNavigationItems(projectId, datasetId, operateType, filters = {}) {
   const currentItem = await db.datasets.findUnique({
     where: { id: datasetId }
   });
   if (!currentItem) {
     throw new Error('Current record does not exist');
   }
+
+  const {
+    confirmed,
+    input = '',
+    field = 'question',
+    hasCot = 'all',
+    isDistill = 'all',
+    scoreRange = '',
+    customTag = '',
+    noteKeyword = '',
+    chunkName = ''
+  } = filters;
+
+  // Build filter conditions to mirror getDatasetsByPagination
+  const searchCondition = {};
+  if (input) {
+    if (field === 'question') searchCondition.question = { contains: input };
+    else if (field === 'answer') searchCondition.answer = { contains: input };
+    else if (field === 'cot') searchCondition.cot = { contains: input };
+    else if (field === 'questionLabel') searchCondition.questionLabel = { contains: input };
+  }
+
+  const cotCondition = {};
+  if (hasCot === 'yes') cotCondition.cot = { not: '' };
+  else if (hasCot === 'no') cotCondition.cot = '';
+
+  const distillCondition = {};
+  if (isDistill === 'yes') distillCondition.chunkName = 'Distilled Content';
+  else if (isDistill === 'no') distillCondition.chunkName = { not: 'Distilled Content' };
+
+  const scoreCondition = {};
+  if (scoreRange) {
+    const [minScore, maxScore] = scoreRange.split('-').map(Number);
+    if (!isNaN(minScore) && !isNaN(maxScore)) {
+      scoreCondition.score = { gte: minScore, lte: maxScore };
+    }
+  }
+
+  const tagCondition = {};
+  if (customTag) tagCondition.tags = { contains: customTag };
+
+  const noteCondition = {};
+  if (noteKeyword) noteCondition.note = { contains: noteKeyword };
+
+  const chunkNameCondition = {};
+  if (chunkName) chunkNameCondition.chunkName = { contains: chunkName };
+
+  const filterClause = {
+    projectId,
+    ...(confirmed !== undefined && { confirmed }),
+    ...searchCondition,
+    ...cotCondition,
+    ...distillCondition,
+    ...scoreCondition,
+    ...tagCondition,
+    ...noteCondition,
+    ...chunkNameCondition
+  };
+
   if (operateType === 'prev') {
     return await db.datasets.findFirst({
-      where: { createAt: { gt: currentItem.createAt }, projectId },
+      where: { ...filterClause, createAt: { gt: currentItem.createAt } },
       orderBy: { createAt: 'asc' }
     });
   } else {
     return await db.datasets.findFirst({
-      where: { createAt: { lt: currentItem.createAt }, projectId },
+      where: { ...filterClause, createAt: { lt: currentItem.createAt } },
       orderBy: { createAt: 'desc' }
     });
   }


### PR DESCRIPTION
Fixes #684

## Problem

When a user applies filter conditions (e.g. chunk name = `part-30`, confirmed status = `unconfirmed`) on the dataset list page and then opens a dataset, clicking the **prev/next** navigation arrows ignores those filters. The navigation jumps to an arbitrary record outside the filtered subset, making it impossible to review only the filtered items sequentially.

## Solution

Three-layer change following the existing filter pattern in `getDatasetsByPagination`:

1. **`useDatasetDetails.js`** — `handleNavigate` now reads the saved filter state from `localStorage` (using the same key `datasets-filters-{projectId}` that the list page persists) and appends the active conditions as query parameters to the navigation request.

2. **API route** (`/api/projects/[projectId]/datasets/[datasetId]`) — extracts those filter query params and passes them as a `filters` object to `getNavigationItems`.

3. **`lib/db/datasets.js`** — `getNavigationItems` accepts an optional `filters` object and builds a `filterClause` (mirroring the same logic as `getDatasetsByPagination`) that is merged into the Prisma `where` condition, so the next/prev record is always within the active filtered set.

## Testing

- Set filter `confirmed = unconfirmed` on the list page → open a dataset → clicking **next** now only moves to the next *unconfirmed* dataset.
- Set `chunkName = part-30` → navigation stays within `part-30` records.
- With no active filters (defaults), behaviour is unchanged.