### PR TITLE
fix: preserve newlines in text preview mode so markdown tables render correctly

### DIFF
--- a/components/datasets/EditableField.js
+++ b/components/datasets/EditableField.js
@@ -75,7 +75,9 @@ function getValue(value, answerType, useMarkdown, t, onOptimize) {
         <ReactMarkdown>{value}</ReactMarkdown>
       </div>
     ) : (
-      <Typography variant="body1">{value}</Typography>
+      <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+        {value}
+      </Typography>
     );
   } else {
     return (


### PR DESCRIPTION
Fixes #741

## Problem

In the dataset detail view, when the toggle is set to **Text** mode (not Markdown), the answer/question content is rendered with MUI `<Typography variant="body1">`. By default, browsers collapse runs of whitespace and ignore newlines in block elements, so every `\n` in the stored text is silently dropped.

This breaks markdown table formatting: the pipe-delimited rows that look correct in the edit textarea are all collapsed onto a single line in preview.

## Solution

Add `sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}` to the `Typography` element used in text mode (`components/datasets/EditableField.js`):

- `pre-wrap` — preserves newlines and spaces while still wrapping long lines.
- `break-word` — prevents long unbreakable strings from overflowing the container.

Single-line change; no behaviour change for Markdown mode or edit mode.

## Testing

1. Open a dataset whose answer contains a markdown table.
2. Toggle to **Text** mode.
3. Before: all rows appear on one line.  After: each row appears on its own line, table structure is visible.