### PR TITLE
build: move the compilation tool to pnpm

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -18,15 +18,15 @@ jobs:
         include:
           - name: Windows
             os: windows-latest
-            build_command: pnpm run electron-build-win -- --publish never
+            build_command: pnpm run electron-build-win-ci
             artifact_name: easy-dataset-windows
           - name: macOS
             os: macos-latest
-            build_command: pnpm run electron-build-mac -- --publish never
+            build_command: pnpm run electron-build-mac-ci
             artifact_name: easy-dataset-macos
           - name: Linux
             os: ubuntu-latest
-            build_command: pnpm run electron-build-linux -- --publish never
+            build_command: pnpm run electron-build-linux-ci
             artifact_name: easy-dataset-linux
 
     steps:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -48,9 +48,14 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
+          if apt-cache show libasound2t64 >/dev/null 2>&1; then
+            ASOUND_PACKAGE=libasound2t64
+          else
+            ASOUND_PACKAGE=libasound2
+          fi
           sudo apt-get install -y --no-install-recommends \
             libarchive-tools \
-            libasound2 \
+            "$ASOUND_PACKAGE" \
             libatk-bridge2.0-0 \
             libdrm2 \
             libgbm1 \

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -86,6 +86,6 @@ jobs:
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact_name }}-${{ github.run_number }}
+          name: ${{ matrix.artifact_name }}
           path: dist/
           if-no-files-found: error

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -35,8 +35,7 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.5.2
+        # pnpm 的版本已经在package.json中标记了
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -20,14 +20,17 @@ jobs:
             os: windows-latest
             build_command: pnpm run electron-build-win-ci
             artifact_name: easy-dataset-windows
+            artifact_path: dist/*.exe
           - name: macOS
             os: macos-latest
             build_command: pnpm run electron-build-mac-ci
             artifact_name: easy-dataset-macos
+            artifact_path: dist/*.dmg
           - name: Linux
             os: ubuntu-latest
             build_command: pnpm run electron-build-linux-ci
             artifact_name: easy-dataset-linux
+            artifact_path: dist/*.AppImage
 
     steps:
       - name: Checkout
@@ -87,5 +90,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}-${{ github.run_number }}
-          path: dist/
+          path: ${{ matrix.artifact_path }}
           if-no-files-found: error

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,0 +1,78 @@
+name: Build Desktop Artifacts
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+            build_command: pnpm electron-build-win
+            artifact_name: easy-dataset-windows
+          - name: macOS
+            os: macos-latest
+            build_command: pnpm electron-build-mac
+            artifact_name: easy-dataset-macos
+          - name: Linux
+            os: ubuntu-latest
+            build_command: pnpm electron-build-linux
+            artifact_name: easy-dataset-linux
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libarchive-tools \
+            libasound2 \
+            libatk-bridge2.0-0 \
+            libdrm2 \
+            libgbm1 \
+            libgtk-3-0 \
+            libnotify4 \
+            libnss3 \
+            libsecret-1-0 \
+            libxkbcommon0 \
+            libxss1 \
+            rpm \
+            xdg-utils
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build desktop app
+        run: ${{ matrix.build_command }}
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}-${{ github.run_number }}
+          path: dist/
+          if-no-files-found: error

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -18,15 +18,15 @@ jobs:
         include:
           - name: Windows
             os: windows-latest
-            build_command: pnpm electron-build-win
+            build_command: pnpm run electron-build-win -- --publish never
             artifact_name: easy-dataset-windows
           - name: macOS
             os: macos-latest
-            build_command: pnpm electron-build-mac
+            build_command: pnpm run electron-build-mac -- --publish never
             artifact_name: easy-dataset-macos
           - name: Linux
             os: ubuntu-latest
-            build_command: pnpm electron-build-linux
+            build_command: pnpm run electron-build-linux -- --publish never
             artifact_name: easy-dataset-linux
 
     steps:
@@ -43,6 +43,15 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json', 'next.config.js', 'next.config.mjs', 'app/**/*.[jt]s', 'app/**/*.[jt]sx', 'components/**/*.[jt]s', 'components/**/*.[jt]sx', 'lib/**/*.[jt]s', 'lib/**/*.[jt]sx', 'electron/**/*.[jt]s', 'electron/**/*.[jt]sx', 'prisma/schema.prisma', 'public/**/*', 'locales/**/*') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
 
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -24,8 +24,6 @@ jobs:
           - name: macOS
             os: macos-latest
             build_command: pnpm run electron-build-mac-ci
-            artifact_name: easy-dataset-macos
-            artifact_path: dist/*.dmg
           - name: Linux
             os: ubuntu-latest
             build_command: pnpm run electron-build-linux-ci
@@ -86,7 +84,35 @@ jobs:
       - name: Build desktop app
         run: ${{ matrix.build_command }}
 
-      - name: Upload dist artifact
+      - name: Separate macOS DMGs
+        if: runner.os == 'macOS'
+        run: |
+          for f in dist/*.dmg; do
+            if [[ "$f" == *"-arm64.dmg" ]]; then
+              cp "$f" dist/easy-dataset-macos-arm64.dmg
+            else
+              cp "$f" dist/easy-dataset-macos-x64.dmg
+            fi
+          done
+
+      - name: Upload macOS (arm64)
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v4
+        with:
+          name: easy-dataset-macos-arm64
+          path: dist/easy-dataset-macos-arm64.dmg
+          if-no-files-found: error
+
+      - name: Upload macOS (x64)
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v4
+        with:
+          name: easy-dataset-macos-x64
+          path: dist/easy-dataset-macos-x64.dmg
+          if-no-files-found: error
+
+      - name: Upload dist artifact (Windows & Linux)
+        if: runner.os != 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}

--- a/next.config.js
+++ b/next.config.js
@@ -1,19 +1,7 @@
 // 最佳实践配置示例
 module.exports = {
   experimental: {
-    serverComponentsExternalPackages: ['@opendocsg/pdf2md', 'pdfjs-dist', '@hyzyla/pdfium'],
+    serverComponentsExternalPackages: ['@opendocsg/pdf2md', '@hyzyla/pdfium', 'pdf2md-js', 'sharp'],
     esmExternals: 'loose'
-  },
-  webpack: (config, { isServer }) => {
-    if (!isServer) {
-      config.externals.push({
-        unpdf: 'window.unpdf',
-        'pdfjs-dist': 'window.pdfjsLib'
-      });
-    } else {
-      config.externals.push('pdfjs-dist');
-      config.externals.push('@hyzyla/pdfium');
-    }
-    return config;
   }
 };

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
       "buildResources": "public",
       "output": "dist"
     },
+    "npmRebuild": false,
     "asar": true,
     "asarUnpack": [
       "**/node_modules/sharp/**/*",
@@ -181,5 +182,6 @@
       "allowToChangeInstallationDirectory": true,
       "perMachine": false
     }
-  }
+  },
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "clean-dist": "rm -rf dist",
     "electron-build": "pnpm clean-dist && pnpm db:template && prisma db push && next build && electron-builder -mwl",
     "electron-build-mac": "pnpm clean-dist && pnpm db:template && prisma db push && next build && electron-builder --mac",
+    "electron-build-mac-ci": "pnpm clean-dist && pnpm db:template && prisma db push && next build && electron-builder --mac --publish never",
     "electron-build-win": "pnpm clean-dist && pnpm db:template && prisma db push && next build && electron-builder --win",
+    "electron-build-win-ci": "pnpm clean-dist && pnpm db:template && prisma db push && next build && electron-builder --win --publish never",
     "electron-build-linux": "pnpm clean-dist && pnpm db:template && prisma db push && next build && electron-builder --linux",
+    "electron-build-linux-ci": "pnpm clean-dist && pnpm db:template && prisma db push && next build && electron-builder --linux --publish never",
     "docker": "docker build -t easy-dataset .",
     "prettier": "npx prettier --write ."
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+nodeLinker: hoisted
+
+allowBuilds:
+  '@prisma/client': true
+  '@prisma/engines': true
+  canvas: true
+  electron: true
+  prisma: true
+  sharp: true


### PR DESCRIPTION
### 变更类型

- [ ] 新功能（feat）
- [ ] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）
- [x] 构建（build）

### 变更描述- 简要说明修改内容

当前package.json中使用了pnpm命令，但进行构建用的又是npm命令。这两者在行为上存在差异，混用可能会让人感到疑惑。请考虑是否要把包管理工具统一迁移至pnpm。

- [ ] 贡献指南

提供了一个可供测试的action工作流配置文件

- [ ] 接口文档
