### PR TITLE
Update Groq default endpoint URL for model usage

### DIFF
--- a/constant/model.js
+++ b/constant/model.js
@@ -49,7 +49,7 @@ export const MODEL_PROVIDERS = [
   {
     id: 'groq',
     name: 'Groq',
-    defaultEndpoint: 'https://api.groq.com/openai',
+    defaultEndpoint: 'https://api.groq.com/openai/v1',
     defaultModels: ['Gemma 7B', 'LLaMA3 8B', 'LLaMA3 70B']
   },
   {


### PR DESCRIPTION
Updated the URL of groq so anyone can use the URL with v1 in last, any should not have to change the URL manualy

Previous: https://api.groq.com/openai

after:  https://api.groq.com/openai/v1


### 变更类型- [ ] 新功能（feat）

- [ ] 修复（fix）
- [ ] 文档（docs）
- [ ] 重构（refactor）

### 变更描述- 简要说明修改内容（关联Issue：#123）

### 文档更新- [ ] README.md

- [ ] 贡献指南
- [ ] 接口文档（如有）
